### PR TITLE
Fix: Add branch validation to shards create command (#33)

### DIFF
--- a/.kiro/artifacts/code-review-reports/review-PR-39-2026-01-20.md
+++ b/.kiro/artifacts/code-review-reports/review-PR-39-2026-01-20.md
@@ -1,0 +1,263 @@
+# Code Review Report
+
+**Scope**: PR #39 - Fix: Add branch validation to shards create command (#33)
+**Date**: 2026-01-20 15:25
+**Reviewers**: code-reviewer, comment-analyzer, error-hunter, type-analyzer, doc-updater
+
+---
+
+## Executive Summary
+
+**Overall Assessment**: APPROVED
+**Risk Level**: LOW
+
+| Metric | Count |
+|--------|-------|
+| Critical Issues | 0 |
+| Important Issues | 2 |
+| Suggestions | 3 |
+| Documentation Updates | 0 |
+
+**Recommendation**: This PR implements smart branch detection to prevent duplicate branches when users are already on the target branch. The implementation follows established patterns, includes proper error handling, and maintains backward compatibility. The two important issues are minor improvements that should be addressed before merge.
+
+---
+
+## Important Issues (Should Fix)
+
+### Issue 1: Missing Error Handling for Detached HEAD
+
+**Location**: `src/git/operations.rs:69-76`
+**Source**: error-hunter
+**Confidence**: 85%
+
+**Problem**:
+The `get_current_branch()` function handles the case where `head.shorthand()` returns `None` by returning `Ok(None)`, but doesn't provide context about why this happened. In a detached HEAD state, users might be confused about the branch naming behavior.
+
+**Why This Matters**:
+Users in detached HEAD state will get `worktree-` prefixed branches without understanding why, leading to confusion about the smart branch detection feature.
+
+**Fix Options**:
+
+| Option | Approach | Pros | Cons |
+|--------|----------|------|------|
+| A (Recommended) | Add debug logging for detached HEAD | Clear debugging info, no breaking changes | Minimal user-facing improvement |
+| B | Return specific error for detached HEAD | Explicit error handling | More complex, might break workflows |
+| C | Add comment explaining None case | Documents behavior | No runtime improvement |
+
+**Recommended Fix**:
+```rust
+pub fn get_current_branch(repo: &git2::Repository) -> Result<Option<String>, GitError> {
+    let head = repo.head().map_err(|e| GitError::Git2Error { source: e })?;
+    
+    if let Some(branch_name) = head.shorthand() {
+        Ok(Some(branch_name.to_string()))
+    } else {
+        // Detached HEAD state - no current branch
+        debug!("Repository is in detached HEAD state, no current branch available");
+        Ok(None)
+    }
+}
+```
+
+---
+
+### Issue 2: Unused BranchConflict Error Variant
+
+**Location**: `src/git/errors.rs:26-32`
+**Source**: type-analyzer
+**Confidence**: 90%
+
+**Problem**:
+The `BranchConflict` error variant is added but never used in the current implementation. This creates dead code and suggests incomplete implementation.
+
+**Why This Matters**:
+Dead code increases maintenance burden and suggests the feature might be incomplete. Future developers might be confused about when this error should be used.
+
+**Fix Options**:
+
+| Option | Approach | Pros | Cons |
+|--------|----------|------|------|
+| A (Recommended) | Remove unused error variant | Clean code, no dead code | Might need to re-add later |
+| B | Add TODO comment explaining future use | Documents intent | Still dead code |
+| C | Implement validation that uses this error | Complete feature | Adds complexity not in scope |
+
+**Recommended Fix**:
+Remove the `BranchConflict` error variant since it's not used in this PR. If future validation needs it, it can be added then.
+
+---
+
+## Suggestions (Nice to Have)
+
+### Suggestion 1: Enhance Branch Decision Logging
+
+**Location**: `src/git/handler.rs:164-172`
+**Source**: code-reviewer
+
+**Current State**: Basic logging of branch decision with boolean flag
+**Improvement**: Add more context about why the decision was made
+**Benefit**: Better debugging and user understanding
+
+```rust
+info!(
+    event = "git.worktree.branch_decision",
+    project_id = project.id,
+    requested_branch = validated_branch,
+    current_branch = current_branch.as_deref().unwrap_or("none"),
+    used_current = use_current,
+    worktree_name = worktree_name,
+    reason = if use_current { "current_branch_matches" } else { "current_branch_different" }
+);
+```
+
+---
+
+### Suggestion 2: Add Function Documentation
+
+**Location**: `src/git/operations.rs:69-80`
+**Source**: comment-analyzer
+
+**Current State**: Functions lack documentation comments
+**Improvement**: Add rustdoc comments explaining behavior and edge cases
+**Benefit**: Better API documentation and maintainability
+
+```rust
+/// Gets the current branch name from the repository.
+/// 
+/// Returns `None` if the repository is in a detached HEAD state.
+/// 
+/// # Errors
+/// Returns `GitError::Git2Error` if the repository HEAD cannot be accessed.
+pub fn get_current_branch(repo: &git2::Repository) -> Result<Option<String>, GitError> {
+    // ... existing implementation
+}
+
+/// Determines if the current branch should be used for the worktree.
+/// 
+/// Returns `true` if the current branch name exactly matches the requested branch name.
+pub fn should_use_current_branch(current_branch: &str, requested_branch: &str) -> bool {
+    // ... existing implementation
+}
+```
+
+---
+
+### Suggestion 3: Improve Test Coverage
+
+**Location**: `src/git/operations.rs:174-182`
+**Source**: test-analyzer
+
+**Current State**: Only tests `should_use_current_branch` function
+**Improvement**: Add tests for `get_current_branch` with different repository states
+**Benefit**: Better confidence in edge case handling
+
+---
+
+## Detailed Agent Reports
+
+### Code Quality Analysis (code-reviewer)
+
+**Files Reviewed**: src/git/operations.rs, src/git/handler.rs, src/git/errors.rs
+
+**Findings Summary**:
+The implementation follows established project patterns well. The handler/operations separation is maintained, with pure logic in operations.rs and I/O orchestration in handler.rs. Error handling follows the project's thiserror pattern. The conditional logic is clear and maintainable.
+
+**Patterns Observed**:
+- Good: Follows existing validation function patterns
+- Good: Maintains separation of concerns
+- Good: Uses structured logging consistently
+- Anti-pattern: Unused error variant suggests incomplete planning
+
+---
+
+### Documentation Analysis (comment-analyzer)
+
+**Comments Reviewed**: 0 new comments, functions lack documentation
+
+**Findings Summary**:
+The new functions lack rustdoc comments, which is inconsistent with other public functions in the codebase. The implementation is self-documenting but would benefit from explicit documentation of edge cases.
+
+**Comment Quality Score**: 6/10 (functions work but lack documentation)
+
+---
+
+### Error Handling Analysis (error-hunter)
+
+**Error Handlers Reviewed**: 2 new functions, 1 new error variant
+
+**Findings Summary**:
+Error handling is generally good, following the project's pattern of using `?` operator and proper error propagation. The main concern is the lack of context for detached HEAD state, which could confuse users.
+
+**Silent Failure Risk**: LOW (proper error propagation maintained)
+
+---
+
+### Type Design Analysis (type-analyzer)
+
+**Types Reviewed**: BranchConflict error variant, function signatures
+
+**Findings Summary**:
+Type safety is maintained well. Function signatures are clear and appropriate. The main issue is the unused BranchConflict error variant, which suggests incomplete implementation or over-engineering.
+
+**Overall Type Safety Score**: 8/10 (good design, minor dead code issue)
+
+---
+
+### Documentation Synchronization (doc-updater)
+
+**Documentation Files Reviewed**: .kiro/steering/*.md, .claude/skills/shards/SKILL.md
+
+**Documentation Status**: UP-TO-DATE
+
+**Updates Required**:
+- Critical: 0
+- Important: 0
+- Minor: 0
+
+**Key Updates**:
+No documentation updates needed. The changes are internal optimizations that don't affect user-facing behavior or command syntax.
+
+---
+
+## What's Done Well
+
+- **Smart branch detection logic**: Clean, testable implementation that solves the duplicate branch problem
+- **Backward compatibility**: Falls back to `worktree-` prefix when current branch doesn't match
+- **Structured logging**: Proper event-based logging for debugging branch decisions
+- **Test coverage**: Added unit test for the core comparison logic
+- **Error handling**: Follows project patterns with proper error propagation
+- **Investigation artifact**: Comprehensive documentation of the problem and solution
+
+---
+
+## Action Items (Prioritized)
+
+### Must Do (Blocking)
+None - PR is ready for merge
+
+### Should Do (Before Merge)
+1. [ ] Add debug logging for detached HEAD case in `get_current_branch()` - improves debugging
+2. [ ] Remove unused `BranchConflict` error variant - eliminates dead code
+
+### Consider (Optional)
+1. [ ] Add rustdoc comments to new functions - improves maintainability
+2. [ ] Enhance branch decision logging with reason field - better debugging
+3. [ ] Add tests for `get_current_branch()` with different repository states - better coverage
+
+---
+
+## Decision Guide
+
+**If you have limited time**, focus on:
+1. Remove unused `BranchConflict` error variant
+2. Add debug logging for detached HEAD
+
+**If you want thorough improvement**, also address:
+1. Add function documentation
+2. Enhance logging with reason field
+
+**Quick wins** (easy fixes with good impact):
+1. Remove unused error variant (30 seconds, eliminates dead code)
+
+---
+
+*Review generated by Kiro AI agents*

--- a/src/git/errors.rs
+++ b/src/git/errors.rs
@@ -23,12 +23,6 @@ pub enum GitError {
     #[error("Git operation failed: {message}")]
     OperationFailed { message: String },
 
-    #[error("Branch '{branch}' conflicts with current branch '{current}'")]
-    BranchConflict { 
-        branch: String, 
-        current: String 
-    },
-
     #[error("Git2 library error: {source}")]
     Git2Error {
         #[from]
@@ -52,7 +46,6 @@ impl ShardsError for GitError {
             GitError::WorktreeAlreadyExists { .. } => "WORKTREE_ALREADY_EXISTS",
             GitError::WorktreeNotFound { .. } => "WORKTREE_NOT_FOUND",
             GitError::OperationFailed { .. } => "GIT_OPERATION_FAILED",
-            GitError::BranchConflict { .. } => "BRANCH_CONFLICT",
             GitError::Git2Error { .. } => "GIT2_ERROR",
             GitError::IoError { .. } => "GIT_IO_ERROR",
         }
@@ -65,7 +58,6 @@ impl ShardsError for GitError {
                 | GitError::BranchAlreadyExists { .. }
                 | GitError::BranchNotFound { .. }
                 | GitError::WorktreeAlreadyExists { .. }
-                | GitError::BranchConflict { .. }
         )
     }
 }

--- a/src/git/handler.rs
+++ b/src/git/handler.rs
@@ -167,7 +167,8 @@ pub fn create_worktree(
         requested_branch = validated_branch,
         current_branch = current_branch.as_deref().unwrap_or("none"),
         used_current = use_current,
-        worktree_name = worktree_name
+        worktree_name = worktree_name,
+        reason = if use_current { "current_branch_matches" } else { "current_branch_different" }
     );
 
     // Copy include pattern files if configured


### PR DESCRIPTION
## Summary

The `shards create` command always creates new branches with `worktree-{branch-name}` prefix, even when the user is already on a branch that should be used for the work. This leads to duplicate branches and merge conflicts when users expect to work on their current branch.

## Root Cause

Hard-coded worktree naming without branch context awareness - the system always prefixes branch names with "worktree-" regardless of whether the user is already on an appropriate branch.

## Changes

| File | Change |
|------|--------|
| `src/git/operations.rs` | Added `get_current_branch()` and `should_use_current_branch()` functions |
| `src/git/handler.rs` | Updated worktree creation logic to conditionally name worktrees based on current branch |
| `src/git/errors.rs` | Added `BranchConflict` error variant for future validation |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [x] New test for branch comparison logic

## Validation

```bash
cargo test should_use_current_branch && cargo test git:: && cargo check
```

## Issue

Fixes #33

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:
`.archon/artifacts/issues/issue-33.md`

### Deviations from plan:
None - implementation follows the artifact exactly

### Key Changes:
1. **Smart Branch Detection**: Added `get_current_branch()` to detect the current Git branch
2. **Conditional Naming**: Worktrees now use the branch name directly when it matches the current branch, otherwise fall back to `worktree-{branch}` prefix
3. **Structured Logging**: Added `git.worktree.branch_decision` event to track branch naming decisions
4. **Error Handling**: Added `BranchConflict` error variant for future validation scenarios

</details>

---
*Automated implementation from investigation artifact*
