### PR TITLE
Added a --flags to `kild code`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,6 +3185,7 @@ dependencies = [
  "clap",
  "kild-core",
  "serde_json",
+ "shlex",
  "tempfile",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ uuid = { version = "1", features = ["v4"] }
 
 # CLI-only dependencies
 clap = { version = "4.0", features = ["derive"] }
+shlex = "1.3"
 
 # Screenshot and image processing dependencies
 xcap = "0.8"

--- a/crates/kild/Cargo.toml
+++ b/crates/kild/Cargo.toml
@@ -14,6 +14,7 @@ kild-core.workspace = true
 clap.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
+shlex.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/kild/src/app.rs
+++ b/crates/kild/src/app.rs
@@ -182,6 +182,13 @@ pub fn build_cli() -> Command {
                         .short('e')
                         .help("Editor to use (defaults to $EDITOR or 'zed')")
                 )
+                .arg(
+                    Arg::new("flags")
+                        .long("flags")
+                        .num_args(1)
+                        .allow_hyphen_values(true)
+                        .help("Additional flags to pass to the editor (use --flags 'value' or --flags='value')")
+                )
         )
         .subcommand(
             Command::new("focus")
@@ -679,6 +686,33 @@ mod tests {
             "test-branch"
         );
         assert_eq!(code_matches.get_one::<String>("editor").unwrap(), "vim");
+    }
+
+    #[test]
+    fn test_cli_code_command_with_complex_flags() {
+        let app = build_cli();
+        let matches = app.try_get_matches_from(vec![
+            "kild",
+            "code",
+            "test-branch",
+            "--editor",
+            "code",
+            "--flags",
+            "--new-window",
+        ]);
+        assert!(matches.is_ok());
+
+        let matches = matches.unwrap();
+        let code_matches = matches.subcommand_matches("code").unwrap();
+        assert_eq!(
+            code_matches.get_one::<String>("branch").unwrap(),
+            "test-branch"
+        );
+        assert_eq!(code_matches.get_one::<String>("editor").unwrap(), "code");
+        assert_eq!(
+            code_matches.get_one::<String>("flags").unwrap(),
+            "--new-window"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Used to add flags to the editor being launched, ie code --new-window

No pressure to merge this but I'm using it to to use `kild code --editor alacritty --flags "--working-directory" <branch>`

This essentially opens up a new terminal and puts the current working directory to the worktree.  If I already have a terminal open, I just use the kcd() shell function in the README.md.

I suppose it also code be used to do something like `code --new-window` ?