### PR TITLE
fix: fetch latest base branch before creating worktree

### DIFF
--- a/crates/kild-core/src/config/mod.rs
+++ b/crates/kild-core/src/config/mod.rs
@@ -46,7 +46,9 @@ pub mod types;
 pub mod validation;
 
 // Public API exports
-pub use types::{AgentConfig, AgentSettings, Config, HealthConfig, KildConfig, TerminalConfig};
+pub use types::{
+    AgentConfig, AgentSettings, Config, GitConfig, HealthConfig, KildConfig, TerminalConfig,
+};
 pub use validation::{VALID_TERMINALS, validate_config};
 
 // Backward-compatible delegation for KildConfig methods

--- a/crates/kild-core/src/git/errors.rs
+++ b/crates/kild-core/src/git/errors.rs
@@ -29,6 +29,9 @@ pub enum GitError {
     #[error("Git operation failed: {message}")]
     OperationFailed { message: String },
 
+    #[error("Failed to fetch from remote '{remote}': {message}")]
+    FetchFailed { remote: String, message: String },
+
     #[error("Git2 library error: {source}")]
     Git2Error {
         #[from]
@@ -54,6 +57,7 @@ impl KildError for GitError {
             GitError::WorktreeRemovalFailed { .. } => "WORKTREE_REMOVAL_FAILED",
             GitError::InvalidPath { .. } => "INVALID_PATH",
             GitError::OperationFailed { .. } => "GIT_OPERATION_FAILED",
+            GitError::FetchFailed { .. } => "GIT_FETCH_FAILED",
             GitError::Git2Error { .. } => "GIT2_ERROR",
             GitError::IoError { .. } => "GIT_IO_ERROR",
         }

--- a/crates/kild-core/src/sessions/handler.rs
+++ b/crates/kild-core/src/sessions/handler.rs
@@ -127,11 +127,22 @@ pub fn create_session(
     );
 
     let base_config = Config::new();
+
+    // Build effective git config with CLI overrides
+    let mut git_config = kild_config.git.clone();
+    if let Some(base) = &request.base_branch {
+        git_config.base_branch = Some(base.clone());
+    }
+    if request.no_fetch {
+        git_config.fetch_before_create = Some(false);
+    }
+
     let worktree = git::handler::create_worktree(
         &base_config.kild_dir,
         &project,
         &validated.name,
         Some(kild_config),
+        &git_config,
     )
     .map_err(|e| SessionError::GitError { source: e })?;
 

--- a/crates/kild-core/src/sessions/types.rs
+++ b/crates/kild-core/src/sessions/types.rs
@@ -283,6 +283,10 @@ pub struct CreateSessionRequest {
     ///
     /// See [`crate::sessions::handler::create_session`] for the branching logic.
     pub project_path: Option<PathBuf>,
+    /// Override base branch for this create (CLI --base flag).
+    pub base_branch: Option<String>,
+    /// Skip fetching before create (CLI --no-fetch flag).
+    pub no_fetch: bool,
 }
 
 impl CreateSessionRequest {
@@ -292,6 +296,8 @@ impl CreateSessionRequest {
             agent,
             note,
             project_path: None,
+            base_branch: None,
+            no_fetch: false,
         }
     }
 
@@ -307,7 +313,19 @@ impl CreateSessionRequest {
             agent,
             note,
             project_path: Some(project_path),
+            base_branch: None,
+            no_fetch: false,
         }
+    }
+
+    pub fn with_base_branch(mut self, base_branch: Option<String>) -> Self {
+        self.base_branch = base_branch;
+        self
+    }
+
+    pub fn with_no_fetch(mut self, no_fetch: bool) -> Self {
+        self.no_fetch = no_fetch;
+        self
     }
 
     pub fn agent(&self) -> String {

--- a/crates/kild/src/app.rs
+++ b/crates/kild/src/app.rs
@@ -55,6 +55,18 @@ pub fn build_cli() -> Command {
                         .short('n')
                         .help("Description of what this kild is for (shown in list/status output)")
                 )
+                .arg(
+                    Arg::new("base")
+                        .long("base")
+                        .short('b')
+                        .help("Base branch to create worktree from (overrides config, default: main)")
+                )
+                .arg(
+                    Arg::new("no-fetch")
+                        .long("no-fetch")
+                        .help("Skip fetching from remote before creating worktree")
+                        .action(ArgAction::SetTrue)
+                )
         )
         .subcommand(
             Command::new("list")
@@ -969,5 +981,63 @@ mod tests {
         let app = build_cli();
         let matches = app.try_get_matches_from(vec!["kild", "complete"]);
         assert!(matches.is_err());
+    }
+
+    #[test]
+    fn test_cli_create_with_base_branch() {
+        let app = build_cli();
+        let matches =
+            app.try_get_matches_from(vec!["kild", "create", "feature-auth", "--base", "develop"]);
+        assert!(matches.is_ok());
+        let matches = matches.unwrap();
+        let create_matches = matches.subcommand_matches("create").unwrap();
+        assert_eq!(create_matches.get_one::<String>("base").unwrap(), "develop");
+    }
+
+    #[test]
+    fn test_cli_create_with_base_short_flag() {
+        let app = build_cli();
+        let matches =
+            app.try_get_matches_from(vec!["kild", "create", "feature-auth", "-b", "develop"]);
+        assert!(matches.is_ok());
+        let matches = matches.unwrap();
+        let create_matches = matches.subcommand_matches("create").unwrap();
+        assert_eq!(create_matches.get_one::<String>("base").unwrap(), "develop");
+    }
+
+    #[test]
+    fn test_cli_create_with_no_fetch() {
+        let app = build_cli();
+        let matches =
+            app.try_get_matches_from(vec!["kild", "create", "feature-auth", "--no-fetch"]);
+        assert!(matches.is_ok());
+        let matches = matches.unwrap();
+        let create_matches = matches.subcommand_matches("create").unwrap();
+        assert!(create_matches.get_flag("no-fetch"));
+    }
+
+    #[test]
+    fn test_cli_create_with_base_and_no_fetch() {
+        let app = build_cli();
+        let matches = app.try_get_matches_from(vec![
+            "kild",
+            "create",
+            "feature-auth",
+            "--base",
+            "develop",
+            "--no-fetch",
+        ]);
+        assert!(matches.is_ok());
+    }
+
+    #[test]
+    fn test_cli_create_no_fetch_default_false() {
+        let app = build_cli();
+        let matches = app.try_get_matches_from(vec!["kild", "create", "feature-auth"]);
+        assert!(matches.is_ok());
+        let matches = matches.unwrap();
+        let create_matches = matches.subcommand_matches("create").unwrap();
+        assert!(!create_matches.get_flag("no-fetch"));
+        assert!(create_matches.get_one::<String>("base").is_none());
     }
 }


### PR DESCRIPTION
## Summary

`kild create` was branching new worktrees from `repo.head()` — the local HEAD commit — without fetching from remote first. When local main falls behind `origin/main`, new kilds start from stale code, causing avoidable merge conflicts when PRs are opened.

## Root Cause

`create_worktree()` in `git/handler.rs:186` used `repo.head()` as the base commit without ever contacting the remote. The entire create flow (CLI -> `create_session()` -> `create_worktree()`) never fetched.

## Changes

| File | Change |
|------|--------|
| `config/types.rs` | Add `GitConfig` struct with `remote`, `base_branch`, `fetch_before_create` |
| `config/defaults.rs` | Add defaults (origin, main, true) and `Default` impl |
| `config/loading.rs` | Add git config merging in `merge_configs()` |
| `config/mod.rs` | Export `GitConfig` |
| `git/errors.rs` | Add `FetchFailed` error variant |
| `git/handler.rs` | Add `fetch_remote()`, `resolve_base_commit()`, update `create_worktree()` |
| `sessions/handler.rs` | Pass git config with CLI overrides to `create_worktree()` |
| `sessions/types.rs` | Add `base_branch` and `no_fetch` to `CreateSessionRequest` |
| `app.rs` | Add `--base` and `--no-fetch` CLI flags |
| `commands.rs` | Wire new CLI flags to request |

## Testing

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes (973 tests)
- [x] `cargo build --all` passes

## Validation

```bash
cargo fmt --check && cargo clippy --all -- -D warnings && cargo test --all && cargo build --all
```

## Issue

Fixes #196

---

<details>
<summary>Implementation Details</summary>

### Key Design Decisions

- **Shell out to `git fetch`** (not git2) — inherits user's SSH agent, credential helpers, etc. Same pattern as existing `git push --delete` in sessions/handler.rs.
- **Resolve remote tracking branch** via git2 `find_reference("refs/remotes/origin/main")` after fetch.
- **Fall back to HEAD** if remote ref doesn't exist — graceful degradation for repos without remotes or offline with `--no-fetch`.
- **Config hierarchy** applies: CLI `--base`/`--no-fetch` > project config > user config > defaults.

### Usage

```bash
# Default: fetches origin/main, creates branch from it
kild create feature-auth

# Override base branch
kild create feature-auth --base develop

# Skip fetch (offline mode)
kild create feature-auth --no-fetch
```

### Config

```toml
[git]
remote = "origin"           # default
base_branch = "main"        # default
fetch_before_create = true  # default
```

### Deviations from plan

- Artifact was investigated against the `fix/200-kild-branch-namespace` branch which had `kild/` branch naming. Implementation was done against `main` which uses `validated_branch` directly. Core fix is identical.

</details>