### PR TITLE
refactor: reduce manual cx.notify() calls with mutate_state helper

### DIFF
--- a/crates/kild-ui/src/views/main_view.rs
+++ b/crates/kild-ui/src/views/main_view.rs
@@ -240,7 +240,8 @@ impl MainView {
     /// Apply a state mutation and notify GPUI to re-render.
     ///
     /// Use for simple handlers where the entire body is a single state mutation.
-    /// For handlers with branching logic or multiple mutations, use explicit `cx.notify()`.
+    /// For handlers with branching logic, early returns, or multiple mutations,
+    /// use explicit `cx.notify()`.
     fn mutate_state(&mut self, cx: &mut Context<Self>, f: impl FnOnce(&mut AppState)) {
         f(&mut self.state);
         cx.notify();


### PR DESCRIPTION
## Summary

- Remove 2 redundant `cx.notify()` calls (clipboard write had no state mutation, focus terminal success path had no state mutation)
- Add `mutate_state()` helper on `MainView` that pairs a state mutation closure with `cx.notify()`
- Convert 10 simple handlers to use the helper, reducing boilerplate

GPUI requires explicit `cx.notify()` for re-renders — this reduces noise without eliminating the fundamental mechanism. Complex handlers with branching logic keep explicit `cx.notify()` for clarity.

Closes #158

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all -- -D warnings` — 0 errors
- [x] `cargo test --all` — 102 passed
- [x] `cargo build --all` — success
- [ ] Manual: open/cancel create dialog, select kild, refresh, dismiss errors, copy path, focus terminal — all behave identically