### PR TITLE
refactor: move dispatch operations to background executor (phase 4a+4b)

### DIFF
--- a/crates/kild-ui/src/views/main_view.rs
+++ b/crates/kild-ui/src/views/main_view.rs
@@ -424,12 +424,10 @@ impl MainView {
         let branch = branch.to_string();
 
         cx.spawn(async move |this, cx: &mut gpui::AsyncApp| {
+            let branch_for_action = branch.clone();
             let result = cx
                 .background_executor()
-                .spawn({
-                    let branch = branch.clone();
-                    async move { actions::open_kild(branch, None) }
-                })
+                .spawn(async move { actions::open_kild(branch_for_action, None) })
                 .await;
 
             if let Err(e) = this.update(cx, |view, cx| {
@@ -466,12 +464,10 @@ impl MainView {
         let branch = branch.to_string();
 
         cx.spawn(async move |this, cx: &mut gpui::AsyncApp| {
+            let branch_for_action = branch.clone();
             let result = cx
                 .background_executor()
-                .spawn({
-                    let branch = branch.clone();
-                    async move { actions::stop_kild(branch) }
-                })
+                .spawn(async move { actions::stop_kild(branch_for_action) })
                 .await;
 
             if let Err(e) = this.update(cx, |view, cx| {


### PR DESCRIPTION
## Summary

- Move all blocking `Store::dispatch()` calls off the GPUI main thread using `cx.spawn()` + `background_executor().spawn()` + `this.update()`
- Prevents UI freezes during git worktree creation/deletion, terminal spawning, and process termination (100ms-2s)
- Store trait stays synchronous — async boundary lives at the UI action layer only, kild-core and CLI unaffected

## Changes

**`crates/kild-ui/src/actions.rs`** — Changed `create_kild`, `destroy_kild`, `open_kild`, `stop_kild` signatures from `&str` to `String` so they can be moved into async blocks

**`crates/kild-ui/src/views/main_view.rs`** — Converted 6 handlers to async:
- `on_dialog_submit` (create kild)
- `on_confirm_destroy` (destroy kild)
- `on_open_click` / `on_stop_click` (single kild open/stop)
- `on_open_all_click` / `on_stop_all_click` (bulk operations)
- Removed `handle_bulk_operation` helper (inlined into async handlers)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes (0 warnings)
- [x] `cargo test --all` passes (102 tests)
- [x] `cargo build --all` succeeds
- [ ] Manual: run `cargo run -p kild-ui`, verify create/destroy/open/stop don't freeze UI

Closes #159