### PR TITLE
Remove --force flag from kild complete

### DIFF
--- a/.claude/skills/kild/SKILL.md
+++ b/.claude/skills/kild/SKILL.md
@@ -246,7 +246,7 @@ kild destroy feature-auth --force
 
 ### Complete a Kild (PR Cleanup)
 ```bash
-kild complete <branch> [--force]
+kild complete <branch>
 ```
 
 Completes a kild by destroying it and cleaning up the remote branch if the PR was merged.
@@ -255,10 +255,7 @@ Use this when finishing work on a PR. The command adapts to your workflow:
 - If PR was already merged (you ran `gh pr merge` first), it also deletes the orphaned remote branch
 - If PR hasn't been merged yet, it just destroys the kild so `gh pr merge --delete-branch` can work
 
-**Flags**
-- `--force` / `-f` - Force complete even with uncommitted changes
-
-**Note:** Requires `gh` CLI to detect merged PRs. If `gh` is not installed, the command still works but won't auto-delete remote branches.
+**Note:** Always blocks on uncommitted changes (use `kild destroy --force` for forced removal). Requires `gh` CLI to detect merged PRs. If `gh` is not installed, the command still works but won't auto-delete remote branches.
 
 **Workflow A: Complete first, then merge**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,6 @@ cargo run -p kild -- destroy my-branch --force   # Force destroy (bypass git che
 cargo run -p kild -- destroy --all               # Destroy all kilds (with confirmation)
 cargo run -p kild -- destroy --all --force       # Force destroy all (skip confirmation)
 cargo run -p kild -- complete my-branch          # Complete kild (check PR, cleanup)
-cargo run -p kild -- complete my-branch --force  # Force complete (bypass git checks)
 
 # kild-peek - Native app inspection and interaction
 cargo run -p kild-peek -- list windows           # List all visible windows

--- a/crates/kild-core/src/state/dispatch.rs
+++ b/crates/kild-core/src/state/dispatch.rs
@@ -64,8 +64,8 @@ impl Store for CoreStore {
                 session_ops::stop_session(&branch)?;
                 Ok(vec![Event::KildStopped { branch }])
             }
-            Command::CompleteKild { branch, force } => {
-                session_ops::complete_session(&branch, force)?;
+            Command::CompleteKild { branch } => {
+                session_ops::complete_session(&branch)?;
                 Ok(vec![Event::KildCompleted { branch }])
             }
             Command::UpdateAgentStatus { branch, status } => {

--- a/crates/kild-core/src/state/store.rs
+++ b/crates/kild-core/src/state/store.rs
@@ -141,7 +141,6 @@ mod tests {
         let events = store
             .dispatch(Command::CompleteKild {
                 branch: "feat".to_string(),
-                force: false,
             })
             .unwrap();
         assert!(matches!(&events[0], Event::KildCompleted { branch } if branch == "feat"));
@@ -233,7 +232,6 @@ mod tests {
             },
             Command::CompleteKild {
                 branch: "b".to_string(),
-                force: false,
             },
             Command::UpdateAgentStatus {
                 branch: "b".to_string(),

--- a/crates/kild-core/src/state/types.rs
+++ b/crates/kild-core/src/state/types.rs
@@ -37,8 +37,8 @@ pub enum Command {
     /// Stop the agent process in a kild without destroying it.
     StopKild { branch: String },
     /// Complete a kild: check if PR was merged, delete remote branch if merged, destroy session.
-    /// The `force` flag bypasses safety checks for session destruction only.
-    CompleteKild { branch: String, force: bool },
+    /// Always blocks on uncommitted changes (use `kild destroy --force` for forced removal).
+    CompleteKild { branch: String },
     /// Update agent status for a kild session.
     UpdateAgentStatus { branch: String, status: AgentStatus },
     /// Refresh the session list from disk.
@@ -90,7 +90,6 @@ mod tests {
             },
             Command::CompleteKild {
                 branch: "feature".to_string(),
-                force: true,
             },
             Command::UpdateAgentStatus {
                 branch: "feature".to_string(),
@@ -140,7 +139,6 @@ mod tests {
             },
             Command::CompleteKild {
                 branch: "test".to_string(),
-                force: false,
             },
             Command::UpdateAgentStatus {
                 branch: "feature".to_string(),

--- a/crates/kild/src/app.rs
+++ b/crates/kild/src/app.rs
@@ -130,13 +130,6 @@ pub fn build_cli() -> Command {
                         .required(true)
                         .index(1)
                 )
-                .arg(
-                    Arg::new("force")
-                        .long("force")
-                        .short('f')
-                        .help("Force completion, bypassing git uncommitted changes check")
-                        .action(ArgAction::SetTrue)
-                )
         )
         .subcommand(
             Command::new("open")
@@ -990,29 +983,14 @@ mod tests {
             complete_matches.get_one::<String>("branch").unwrap(),
             "test-branch"
         );
-        assert!(!complete_matches.get_flag("force"));
     }
 
     #[test]
-    fn test_cli_complete_command_with_force() {
+    fn test_cli_complete_rejects_force_flag() {
         let app = build_cli();
+        // --force should not be accepted on complete (removed in #188)
         let matches = app.try_get_matches_from(vec!["kild", "complete", "test-branch", "--force"]);
-        assert!(matches.is_ok());
-
-        let matches = matches.unwrap();
-        let complete_matches = matches.subcommand_matches("complete").unwrap();
-        assert!(complete_matches.get_flag("force"));
-    }
-
-    #[test]
-    fn test_cli_complete_command_force_short() {
-        let app = build_cli();
-        let matches = app.try_get_matches_from(vec!["kild", "complete", "test-branch", "-f"]);
-        assert!(matches.is_ok());
-
-        let matches = matches.unwrap();
-        let complete_matches = matches.subcommand_matches("complete").unwrap();
-        assert!(complete_matches.get_flag("force"));
+        assert!(matches.is_err());
     }
 
     #[test]

--- a/crates/kild/src/commands.rs
+++ b/crates/kild/src/commands.rs
@@ -398,13 +398,7 @@ fn handle_complete_command(matches: &ArgMatches) -> Result<(), Box<dyn std::erro
         return Err("Invalid branch name".into());
     }
 
-    let force = matches.get_flag("force");
-
-    info!(
-        event = "cli.complete_started",
-        branch = branch,
-        force = force
-    );
+    info!(event = "cli.complete_started", branch = branch);
 
     // Pre-complete safety check (always — complete never bypasses uncommitted check)
     let safety_info = match session_handler::get_destroy_safety_info(branch) {
@@ -448,7 +442,7 @@ fn handle_complete_command(matches: &ArgMatches) -> Result<(), Box<dyn std::erro
         }
     }
 
-    match session_handler::complete_session(branch, force) {
+    match session_handler::complete_session(branch) {
         Ok(result) => {
             use kild_core::CompleteResult;
 


### PR DESCRIPTION
## Summary

- Remove the `--force` flag from `kild complete` since it had no meaningful effect after #187 made `complete` unconditionally block on uncommitted changes
- Users who need forced removal should use `kild destroy --force` instead

## Changes

| File | Change |
|------|--------|
| `crates/kild/src/app.rs` | Remove `--force`/`-f` arg from complete subcommand |
| `crates/kild/src/commands.rs` | Remove force reading, simplify logging |
| `crates/kild-core/src/sessions/handler.rs` | Remove `force` param from `complete_session()`, hardcode `false` in `destroy_session()` call |
| `crates/kild-core/src/state/types.rs` | Remove `force` from `CompleteKild` command variant |
| `crates/kild-core/src/state/dispatch.rs` | Update destructure pattern |
| `crates/kild-core/src/state/store.rs` | Update test usages |
| `CLAUDE.md` | Remove `--force` from complete examples |
| `.claude/skills/kild/SKILL.md` | Remove `--force` from complete reference |

## Testing

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes (120 tests)
- [x] `cargo build --all` succeeds
- [x] Added test verifying `--force` is now rejected on `complete`

## Rationale

`complete` and `destroy` are semantically distinct:
- `complete` = clean PR-aware finish (always refuses dirty worktrees)
- `destroy --force` = deliberate destructive action (user accepts data loss)

Having `--force` on `complete` was confusing — users expect it to override, but it doesn't and shouldn't.

Fixes #188