### PR TITLE
refactor: introduce EditorBackend trait to decouple editor launching from CLI

### DIFF
--- a/crates/kild-core/src/editor/backends/generic.rs
+++ b/crates/kild-core/src/editor/backends/generic.rs
@@ -1,0 +1,132 @@
+use std::path::Path;
+use std::process::Command;
+
+use tracing::{error, info};
+
+use crate::config::KildConfig;
+use crate::editor::errors::EditorError;
+use crate::editor::traits::EditorBackend;
+use crate::terminal::common::escape::shell_escape;
+use crate::terminal::handler as terminal_ops;
+
+/// Fallback backend for editors not covered by specific backends.
+///
+/// Unlike the known backends (Zed, VSCode, Vim), GenericBackend holds state
+/// (the command name and terminal flag) and is constructed dynamically by the
+/// registry when no known backend matches.
+pub struct GenericBackend {
+    command: String,
+    terminal: bool,
+}
+
+impl GenericBackend {
+    pub fn new(command: String, terminal: bool) -> Self {
+        Self { command, terminal }
+    }
+}
+
+impl EditorBackend for GenericBackend {
+    fn name(&self) -> &'static str {
+        // GenericBackend is dynamically created, so we can't return the command
+        // as &'static str. Return a generic label instead.
+        "generic"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Generic"
+    }
+
+    fn is_available(&self) -> bool {
+        which::which(&self.command).is_ok()
+    }
+
+    fn is_terminal_editor(&self) -> bool {
+        self.terminal
+    }
+
+    fn open(&self, path: &Path, flags: &[String], config: &KildConfig) -> Result<(), EditorError> {
+        info!(
+            event = "core.editor.open_started",
+            editor = %self.command,
+            path = %path.display(),
+            terminal = self.terminal
+        );
+
+        if self.terminal {
+            let escaped_path = shell_escape(&path.display().to_string());
+            let command = if flags.is_empty() {
+                format!("{} {}", self.command, escaped_path)
+            } else {
+                format!("{} {} {}", self.command, flags.join(" "), escaped_path)
+            };
+
+            match terminal_ops::spawn_terminal(path, &command, config, None, None) {
+                Ok(_) => {
+                    info!(
+                        event = "core.editor.open_completed",
+                        editor = %self.command,
+                        terminal = true
+                    );
+                    Ok(())
+                }
+                Err(e) => {
+                    error!(
+                        event = "core.editor.open_failed",
+                        editor = %self.command,
+                        error = %e,
+                        terminal = true
+                    );
+                    Err(EditorError::TerminalSpawnFailed { source: e })
+                }
+            }
+        } else {
+            let mut cmd = Command::new(&self.command);
+            for flag in flags {
+                cmd.arg(flag);
+            }
+            cmd.arg(path);
+
+            match cmd.spawn() {
+                Ok(_) => {
+                    info!(
+                        event = "core.editor.open_completed",
+                        editor = %self.command
+                    );
+                    Ok(())
+                }
+                Err(e) => {
+                    error!(
+                        event = "core.editor.open_failed",
+                        editor = %self.command,
+                        error = %e
+                    );
+                    Err(EditorError::SpawnFailed {
+                        message: format!("{}: {}", self.command, e),
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generic_backend_gui() {
+        let backend = GenericBackend::new("my-editor".to_string(), false);
+        assert_eq!(backend.name(), "generic");
+        assert_eq!(backend.display_name(), "Generic");
+        assert!(!backend.is_terminal_editor());
+        // my-editor is not installed, so is_available should be false
+        assert!(!backend.is_available());
+    }
+
+    #[test]
+    fn test_generic_backend_terminal() {
+        let backend = GenericBackend::new("my-term-editor".to_string(), true);
+        assert!(backend.is_terminal_editor());
+        assert!(!backend.is_available());
+    }
+}

--- a/crates/kild-core/src/editor/backends/mod.rs
+++ b/crates/kild-core/src/editor/backends/mod.rs
@@ -1,0 +1,9 @@
+mod generic;
+mod vim;
+mod vscode;
+mod zed;
+
+pub use generic::GenericBackend;
+pub use vim::VimBackend;
+pub use vscode::VSCodeBackend;
+pub use zed::ZedBackend;

--- a/crates/kild-core/src/editor/backends/vim.rs
+++ b/crates/kild-core/src/editor/backends/vim.rs
@@ -1,0 +1,94 @@
+use std::path::Path;
+
+use tracing::{error, info};
+
+use crate::config::KildConfig;
+use crate::editor::errors::EditorError;
+use crate::editor::traits::EditorBackend;
+use crate::terminal::common::escape::shell_escape;
+use crate::terminal::handler as terminal_ops;
+
+pub struct VimBackend;
+
+impl EditorBackend for VimBackend {
+    fn name(&self) -> &'static str {
+        "vim"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Vim"
+    }
+
+    fn is_available(&self) -> bool {
+        which::which("vim").is_ok() || which::which("nvim").is_ok()
+    }
+
+    fn is_terminal_editor(&self) -> bool {
+        true
+    }
+
+    fn open(&self, path: &Path, flags: &[String], config: &KildConfig) -> Result<(), EditorError> {
+        self.open_with_command("vim", path, flags, config)
+    }
+}
+
+impl VimBackend {
+    /// Open with a specific editor command (vim, nvim, helix, etc.).
+    ///
+    /// This is called by the registry with the resolved editor command name,
+    /// allowing the same backend to handle vim, nvim, and helix.
+    pub fn open_with_command(
+        &self,
+        editor_cmd: &str,
+        path: &Path,
+        flags: &[String],
+        config: &KildConfig,
+    ) -> Result<(), EditorError> {
+        info!(
+            event = "core.editor.open_started",
+            editor = editor_cmd,
+            path = %path.display(),
+            terminal = true
+        );
+
+        let escaped_path = shell_escape(&path.display().to_string());
+        let command = if flags.is_empty() {
+            format!("{} {}", editor_cmd, escaped_path)
+        } else {
+            format!("{} {} {}", editor_cmd, flags.join(" "), escaped_path)
+        };
+
+        match terminal_ops::spawn_terminal(path, &command, config, None, None) {
+            Ok(_) => {
+                info!(
+                    event = "core.editor.open_completed",
+                    editor = editor_cmd,
+                    terminal = true
+                );
+                Ok(())
+            }
+            Err(e) => {
+                error!(
+                    event = "core.editor.open_failed",
+                    editor = editor_cmd,
+                    error = %e,
+                    terminal = true
+                );
+                Err(EditorError::TerminalSpawnFailed { source: e })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vim_backend_identity() {
+        let backend = VimBackend;
+        assert_eq!(backend.name(), "vim");
+        assert_eq!(backend.display_name(), "Vim");
+        assert!(backend.is_terminal_editor());
+    }
+}

--- a/crates/kild-core/src/editor/backends/vscode.rs
+++ b/crates/kild-core/src/editor/backends/vscode.rs
@@ -1,0 +1,72 @@
+use std::path::Path;
+use std::process::Command;
+
+use tracing::{error, info};
+
+use crate::config::KildConfig;
+use crate::editor::errors::EditorError;
+use crate::editor::traits::EditorBackend;
+
+pub struct VSCodeBackend;
+
+impl EditorBackend for VSCodeBackend {
+    fn name(&self) -> &'static str {
+        "code"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "VS Code"
+    }
+
+    fn is_available(&self) -> bool {
+        which::which("code").is_ok()
+    }
+
+    fn is_terminal_editor(&self) -> bool {
+        false
+    }
+
+    fn open(&self, path: &Path, flags: &[String], _config: &KildConfig) -> Result<(), EditorError> {
+        info!(
+            event = "core.editor.open_started",
+            editor = "code",
+            path = %path.display()
+        );
+
+        let mut cmd = Command::new("code");
+        for flag in flags {
+            cmd.arg(flag);
+        }
+        cmd.arg(path);
+
+        match cmd.spawn() {
+            Ok(_) => {
+                info!(event = "core.editor.open_completed", editor = "code");
+                Ok(())
+            }
+            Err(e) => {
+                error!(
+                    event = "core.editor.open_failed",
+                    editor = "code",
+                    error = %e
+                );
+                Err(EditorError::SpawnFailed {
+                    message: format!("code: {}", e),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vscode_backend_identity() {
+        let backend = VSCodeBackend;
+        assert_eq!(backend.name(), "code");
+        assert_eq!(backend.display_name(), "VS Code");
+        assert!(!backend.is_terminal_editor());
+    }
+}

--- a/crates/kild-core/src/editor/backends/zed.rs
+++ b/crates/kild-core/src/editor/backends/zed.rs
@@ -1,0 +1,72 @@
+use std::path::Path;
+use std::process::Command;
+
+use tracing::{error, info};
+
+use crate::config::KildConfig;
+use crate::editor::errors::EditorError;
+use crate::editor::traits::EditorBackend;
+
+pub struct ZedBackend;
+
+impl EditorBackend for ZedBackend {
+    fn name(&self) -> &'static str {
+        "zed"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Zed"
+    }
+
+    fn is_available(&self) -> bool {
+        which::which("zed").is_ok()
+    }
+
+    fn is_terminal_editor(&self) -> bool {
+        false
+    }
+
+    fn open(&self, path: &Path, flags: &[String], _config: &KildConfig) -> Result<(), EditorError> {
+        info!(
+            event = "core.editor.open_started",
+            editor = "zed",
+            path = %path.display()
+        );
+
+        let mut cmd = Command::new("zed");
+        for flag in flags {
+            cmd.arg(flag);
+        }
+        cmd.arg(path);
+
+        match cmd.spawn() {
+            Ok(_) => {
+                info!(event = "core.editor.open_completed", editor = "zed");
+                Ok(())
+            }
+            Err(e) => {
+                error!(
+                    event = "core.editor.open_failed",
+                    editor = "zed",
+                    error = %e
+                );
+                Err(EditorError::SpawnFailed {
+                    message: format!("zed: {}", e),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zed_backend_identity() {
+        let backend = ZedBackend;
+        assert_eq!(backend.name(), "zed");
+        assert_eq!(backend.display_name(), "Zed");
+        assert!(!backend.is_terminal_editor());
+    }
+}

--- a/crates/kild-core/src/editor/errors.rs
+++ b/crates/kild-core/src/editor/errors.rs
@@ -1,0 +1,94 @@
+use crate::errors::KildError;
+use crate::terminal::errors::TerminalError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EditorError {
+    #[error("No supported editor found")]
+    NoEditorFound,
+
+    #[error("Editor '{editor}' not found or not executable")]
+    EditorNotFound { editor: String },
+
+    #[error("Failed to spawn editor process: {message}")]
+    SpawnFailed { message: String },
+
+    #[error("Failed to spawn terminal for editor: {source}")]
+    TerminalSpawnFailed {
+        #[from]
+        source: TerminalError,
+    },
+
+    #[error("IO error during editor operation: {source}")]
+    IoError {
+        #[from]
+        source: std::io::Error,
+    },
+}
+
+impl KildError for EditorError {
+    fn error_code(&self) -> &'static str {
+        match self {
+            EditorError::NoEditorFound => "EDITOR_NOT_FOUND",
+            EditorError::EditorNotFound { .. } => "EDITOR_COMMAND_NOT_FOUND",
+            EditorError::SpawnFailed { .. } => "EDITOR_SPAWN_FAILED",
+            EditorError::TerminalSpawnFailed { .. } => "EDITOR_TERMINAL_SPAWN_FAILED",
+            EditorError::IoError { .. } => "EDITOR_IO_ERROR",
+        }
+    }
+
+    fn is_user_error(&self) -> bool {
+        matches!(
+            self,
+            EditorError::NoEditorFound | EditorError::EditorNotFound { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_editor_found() {
+        let error = EditorError::NoEditorFound;
+        assert_eq!(error.to_string(), "No supported editor found");
+        assert_eq!(error.error_code(), "EDITOR_NOT_FOUND");
+        assert!(error.is_user_error());
+    }
+
+    #[test]
+    fn test_editor_not_found() {
+        let error = EditorError::EditorNotFound {
+            editor: "zed".to_string(),
+        };
+        assert_eq!(
+            error.to_string(),
+            "Editor 'zed' not found or not executable"
+        );
+        assert_eq!(error.error_code(), "EDITOR_COMMAND_NOT_FOUND");
+        assert!(error.is_user_error());
+    }
+
+    #[test]
+    fn test_spawn_failed() {
+        let error = EditorError::SpawnFailed {
+            message: "process exited".to_string(),
+        };
+        assert_eq!(
+            error.to_string(),
+            "Failed to spawn editor process: process exited"
+        );
+        assert_eq!(error.error_code(), "EDITOR_SPAWN_FAILED");
+        assert!(!error.is_user_error());
+    }
+
+    #[test]
+    fn test_io_error() {
+        let error = EditorError::IoError {
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"),
+        };
+        assert!(error.to_string().contains("IO error"));
+        assert_eq!(error.error_code(), "EDITOR_IO_ERROR");
+        assert!(!error.is_user_error());
+    }
+}

--- a/crates/kild-core/src/editor/mod.rs
+++ b/crates/kild-core/src/editor/mod.rs
@@ -1,0 +1,11 @@
+pub mod backends;
+pub mod errors;
+pub mod registry;
+pub mod traits;
+pub mod types;
+
+// Re-export public API
+pub use errors::EditorError;
+pub use registry::{detect_editor, get_backend, open_editor};
+pub use traits::EditorBackend;
+pub use types::EditorType;

--- a/crates/kild-core/src/editor/registry.rs
+++ b/crates/kild-core/src/editor/registry.rs
@@ -1,0 +1,215 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::LazyLock;
+
+use tracing::{debug, info};
+
+use crate::config::KildConfig;
+
+use super::backends::{GenericBackend, VSCodeBackend, VimBackend, ZedBackend};
+use super::errors::EditorError;
+use super::traits::EditorBackend;
+use super::types::EditorType;
+
+/// Global registry of all known editor backends.
+static REGISTRY: LazyLock<EditorRegistry> = LazyLock::new(EditorRegistry::new);
+
+struct EditorRegistry {
+    backends: HashMap<EditorType, Box<dyn EditorBackend>>,
+}
+
+impl EditorRegistry {
+    fn new() -> Self {
+        let mut backends: HashMap<EditorType, Box<dyn EditorBackend>> = HashMap::new();
+        backends.insert(EditorType::Zed, Box::new(ZedBackend));
+        backends.insert(EditorType::VSCode, Box::new(VSCodeBackend));
+        backends.insert(EditorType::Vim, Box::new(VimBackend));
+        Self { backends }
+    }
+
+    fn get(&self, editor_type: &EditorType) -> Option<&dyn EditorBackend> {
+        self.backends.get(editor_type).map(|b| b.as_ref())
+    }
+}
+
+/// Get a reference to an editor backend by type.
+pub fn get_backend(editor_type: &EditorType) -> Option<&'static dyn EditorBackend> {
+    REGISTRY.get(editor_type)
+}
+
+/// Detect available editor in preference order: Zed > VS Code > Vim.
+pub fn detect_editor() -> Result<EditorType, EditorError> {
+    debug!(event = "core.editor.detection_started");
+
+    let editors = [EditorType::Zed, EditorType::VSCode, EditorType::Vim];
+
+    for editor_type in editors {
+        if let Some(backend) = get_backend(&editor_type)
+            && backend.is_available()
+        {
+            debug!(event = "core.editor.detected", editor = backend.name());
+            return Ok(editor_type);
+        }
+    }
+
+    Err(EditorError::NoEditorFound)
+}
+
+/// Resolve which editor to use and return `(command_name, matched_type)`.
+///
+/// Priority: CLI override > config default > $EDITOR > detect_editor().
+/// If the resolved name matches a known EditorType (via FromStr), returns it.
+/// Otherwise returns None (the caller should use GenericBackend).
+fn resolve_editor(
+    cli_override: Option<&str>,
+    config: &KildConfig,
+) -> Result<(String, Option<EditorType>), EditorError> {
+    debug!(
+        event = "core.editor.resolve_started",
+        cli_override = ?cli_override
+    );
+
+    let editor_name = config.editor.resolve_editor(cli_override);
+    let editor_type = editor_name.parse::<EditorType>().ok();
+
+    debug!(
+        event = "core.editor.resolve_completed",
+        editor = %editor_name,
+        editor_type = ?editor_type
+    );
+
+    Ok((editor_name, editor_type))
+}
+
+/// Open a path in the resolved editor.
+///
+/// This is the primary API for both CLI and UI. It resolves which editor
+/// to use, finds or creates the appropriate backend, and opens the path.
+pub fn open_editor(
+    path: &Path,
+    cli_override: Option<&str>,
+    config: &KildConfig,
+) -> Result<(), EditorError> {
+    let (editor_name, editor_type) = resolve_editor(cli_override, config)?;
+
+    // Parse flags from config
+    let flags: Vec<String> = config
+        .editor
+        .flags()
+        .map(|f| f.split_whitespace().map(String::from).collect())
+        .unwrap_or_default();
+
+    info!(
+        event = "core.editor.open_started",
+        editor = %editor_name,
+        editor_type = ?editor_type,
+        path = %path.display()
+    );
+
+    match editor_type {
+        Some(EditorType::Vim) => {
+            // Terminal editors resolve to Vim type but the actual command
+            // may be "nvim", "helix", etc. Use VimBackend::open_with_command
+            // to pass the resolved command name.
+            let backend = VimBackend;
+            backend.open_with_command(&editor_name, path, &flags, config)
+        }
+        Some(et) => {
+            let backend = get_backend(&et).ok_or_else(|| EditorError::EditorNotFound {
+                editor: editor_name.clone(),
+            })?;
+            backend.open(path, &flags, config)
+        }
+        None => {
+            // Unknown editor - use GenericBackend
+            let terminal = config.editor.terminal();
+            let backend = GenericBackend::new(editor_name.clone(), terminal);
+
+            if !backend.is_available() {
+                return Err(EditorError::EditorNotFound {
+                    editor: editor_name,
+                });
+            }
+
+            backend.open(path, &flags, config)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_backend_zed() {
+        let backend = get_backend(&EditorType::Zed);
+        assert!(backend.is_some());
+        assert_eq!(backend.unwrap().name(), "zed");
+    }
+
+    #[test]
+    fn test_get_backend_vscode() {
+        let backend = get_backend(&EditorType::VSCode);
+        assert!(backend.is_some());
+        assert_eq!(backend.unwrap().name(), "code");
+    }
+
+    #[test]
+    fn test_get_backend_vim() {
+        let backend = get_backend(&EditorType::Vim);
+        assert!(backend.is_some());
+        assert_eq!(backend.unwrap().name(), "vim");
+    }
+
+    #[test]
+    fn test_detect_editor_does_not_panic() {
+        let _result = detect_editor();
+    }
+
+    #[test]
+    fn test_registry_contains_expected_editors() {
+        let expected = [EditorType::Zed, EditorType::VSCode, EditorType::Vim];
+        for editor_type in expected {
+            let backend = get_backend(&editor_type);
+            assert!(
+                backend.is_some(),
+                "Registry should contain {:?}",
+                editor_type
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_registered_backends_have_correct_names() {
+        let checks = [
+            (EditorType::Zed, "zed"),
+            (EditorType::VSCode, "code"),
+            (EditorType::Vim, "vim"),
+        ];
+        for (editor_type, expected_name) in checks {
+            let backend = get_backend(&editor_type).unwrap();
+            assert_eq!(
+                backend.name(),
+                expected_name,
+                "Backend for {:?} should have name '{}'",
+                editor_type,
+                expected_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolve_editor_with_cli_override() {
+        let config = KildConfig::default();
+        let (name, _) = resolve_editor(Some("zed"), &config).unwrap();
+        assert_eq!(name, "zed");
+    }
+
+    #[test]
+    fn test_resolve_editor_unknown_returns_none_type() {
+        let config = KildConfig::default();
+        let (name, editor_type) = resolve_editor(Some("my-custom-editor"), &config).unwrap();
+        assert_eq!(name, "my-custom-editor");
+        assert!(editor_type.is_none());
+    }
+}

--- a/crates/kild-core/src/editor/traits.rs
+++ b/crates/kild-core/src/editor/traits.rs
@@ -1,0 +1,80 @@
+use std::path::Path;
+
+use crate::config::KildConfig;
+
+use super::errors::EditorError;
+
+/// Trait defining the interface for editor backends.
+///
+/// Each supported editor (Zed, VS Code, Vim/Neovim, etc.) implements this trait
+/// to provide editor-specific spawning behavior.
+pub trait EditorBackend: Send + Sync {
+    /// The canonical name of this editor (e.g., "zed", "code", "vim").
+    fn name(&self) -> &'static str;
+
+    /// The user-facing display name (e.g., "Zed", "VS Code", "Vim").
+    fn display_name(&self) -> &'static str;
+
+    /// Whether this editor is available on the system.
+    fn is_available(&self) -> bool;
+
+    /// Whether this editor runs inside a terminal (e.g., vim, nvim, helix).
+    fn is_terminal_editor(&self) -> bool;
+
+    /// Open a path in this editor.
+    ///
+    /// For GUI editors, spawns a new process directly.
+    /// For terminal editors, delegates to the terminal backend via `config`.
+    fn open(&self, path: &Path, flags: &[String], config: &KildConfig) -> Result<(), EditorError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockBackend;
+
+    impl EditorBackend for MockBackend {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        fn display_name(&self) -> &'static str {
+            "Mock Editor"
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        fn is_terminal_editor(&self) -> bool {
+            false
+        }
+
+        fn open(
+            &self,
+            _path: &Path,
+            _flags: &[String],
+            _config: &KildConfig,
+        ) -> Result<(), EditorError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_editor_backend_basic_methods() {
+        let backend = MockBackend;
+        assert_eq!(backend.name(), "mock");
+        assert_eq!(backend.display_name(), "Mock Editor");
+        assert!(backend.is_available());
+        assert!(!backend.is_terminal_editor());
+    }
+
+    #[test]
+    fn test_editor_backend_open() {
+        let backend = MockBackend;
+        let config = KildConfig::default();
+        let result = backend.open(Path::new("/tmp"), &[], &config);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/kild-core/src/editor/types.rs
+++ b/crates/kild-core/src/editor/types.rs
@@ -1,0 +1,122 @@
+use serde::{Deserialize, Serialize};
+
+/// Supported editor types.
+///
+/// Each variant represents a known editor with its own backend implementation.
+/// Unknown editors fall back to `GenericBackend` (not represented here since
+/// it's dynamically constructed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EditorType {
+    Zed,
+    VSCode,
+    Vim,
+}
+
+impl EditorType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EditorType::Zed => "zed",
+            EditorType::VSCode => "code",
+            EditorType::Vim => "vim",
+        }
+    }
+}
+
+impl std::fmt::Display for EditorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl std::str::FromStr for EditorType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "zed" => Ok(EditorType::Zed),
+            "code" | "vscode" => Ok(EditorType::VSCode),
+            "vim" | "nvim" | "neovim" | "helix" => Ok(EditorType::Vim),
+            _ => Err(format!(
+                "Unknown editor '{}'. Known editors: zed, code, vim",
+                s
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_editor_type_as_str() {
+        assert_eq!(EditorType::Zed.as_str(), "zed");
+        assert_eq!(EditorType::VSCode.as_str(), "code");
+        assert_eq!(EditorType::Vim.as_str(), "vim");
+    }
+
+    #[test]
+    fn test_editor_type_display() {
+        assert_eq!(format!("{}", EditorType::Zed), "zed");
+        assert_eq!(format!("{}", EditorType::VSCode), "code");
+        assert_eq!(format!("{}", EditorType::Vim), "vim");
+    }
+
+    #[test]
+    fn test_editor_type_from_str_case_insensitive() {
+        use std::str::FromStr;
+        assert_eq!(EditorType::from_str("zed"), Ok(EditorType::Zed));
+        assert_eq!(EditorType::from_str("ZED"), Ok(EditorType::Zed));
+        assert_eq!(EditorType::from_str("Zed"), Ok(EditorType::Zed));
+
+        assert_eq!(EditorType::from_str("code"), Ok(EditorType::VSCode));
+        assert_eq!(EditorType::from_str("vscode"), Ok(EditorType::VSCode));
+        assert_eq!(EditorType::from_str("VSCode"), Ok(EditorType::VSCode));
+
+        assert_eq!(EditorType::from_str("vim"), Ok(EditorType::Vim));
+        assert_eq!(EditorType::from_str("nvim"), Ok(EditorType::Vim));
+        assert_eq!(EditorType::from_str("neovim"), Ok(EditorType::Vim));
+        assert_eq!(EditorType::from_str("helix"), Ok(EditorType::Vim));
+
+        assert!(EditorType::from_str("unknown").is_err());
+        assert!(EditorType::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_editor_type_from_str_error_message() {
+        use std::str::FromStr;
+        let err = EditorType::from_str("unknown").unwrap_err();
+        assert!(err.contains("Unknown editor 'unknown'"));
+        assert!(err.contains("zed"));
+    }
+
+    #[test]
+    fn test_editor_type_serde() {
+        let zed = EditorType::Zed;
+        let json = serde_json::to_string(&zed).unwrap();
+        assert_eq!(json, "\"zed\"");
+
+        let parsed: EditorType = serde_json::from_str("\"zed\"").unwrap();
+        assert_eq!(parsed, EditorType::Zed);
+
+        let parsed: EditorType = serde_json::from_str("\"vscode\"").unwrap();
+        assert_eq!(parsed, EditorType::VSCode);
+
+        let parsed: EditorType = serde_json::from_str("\"vim\"").unwrap();
+        assert_eq!(parsed, EditorType::Vim);
+    }
+
+    #[test]
+    fn test_editor_type_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(EditorType::Zed);
+        set.insert(EditorType::Zed);
+        assert_eq!(set.len(), 1);
+
+        set.insert(EditorType::VSCode);
+        set.insert(EditorType::Vim);
+        assert_eq!(set.len(), 3);
+    }
+}

--- a/crates/kild-core/src/lib.rs
+++ b/crates/kild-core/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod agents;
 pub mod cleanup;
 pub mod config;
+pub mod editor;
 pub mod errors;
 pub mod events;
 pub mod files;
@@ -29,6 +30,7 @@ pub mod terminal;
 
 // Re-export commonly used types at crate root for convenience
 pub use config::KildConfig;
+pub use editor::{EditorBackend, EditorError, EditorType};
 pub use forge::types::{CiStatus, PrCheckResult, PrInfo, PrState, ReviewStatus};
 pub use forge::{ForgeBackend, ForgeError, ForgeType};
 pub use git::types::{DiffStats, GitStats, UncommittedDetails, WorktreeStatus};


### PR DESCRIPTION
## Summary

- Introduce `EditorBackend` trait in `kild-core` following the established backend pattern (trait + registry + backends) used by `TerminalBackend` and `ForgeBackend`
- Add four backends: `ZedBackend`, `VSCodeBackend`, `VimBackend` (terminal editors), and `GenericBackend` (dynamic fallback)
- Create `LazyLock` registry with `detect_editor()`, `resolve_editor()`, and `open_editor()` convenience function
- Refactor CLI `handle_code_command` from 116 lines of branching logic to a thin wrapper calling `editor::open_editor()`
- Remove `build_terminal_command` and `build_gui_command` from `EditorConfig` (logic moved into backends)

Closes #267

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes (0 warnings)
- [x] `cargo test --all` passes (35 new editor tests + all existing tests)
- [x] `cargo build --all` compiles cleanly
- [ ] Manual test: `kild code <branch>` opens editor correctly
- [ ] Manual test: `kild code <branch> --editor vim` overrides editor