### PR TITLE
feat: add scrollback buffer and scroll wheel support to embedded terminal

### DIFF
--- a/crates/kild-ui/src/terminal/terminal_element.rs
+++ b/crates/kild-ui/src/terminal/terminal_element.rs
@@ -586,6 +586,11 @@ impl Element for TerminalElement {
                 cx,
             ) {
                 tracing::error!(event = "ui.terminal.badge_paint_failed", error = %e);
+                // Fallback: thin accent bar so the user still sees "scrolled up".
+                window.paint_quad(fill(
+                    Bounds::new(point(badge_x, badge_y), size(badge_width, px(2.0))),
+                    badge_fg,
+                ));
             }
         }
 


### PR DESCRIPTION
## Summary

- Wire GPUI `ScrollWheelEvent` to alacritty_terminal's `scroll_display()` via hitbox-based mouse event listener in `TerminalElement`
- Support both trackpad (pixel deltas) and mouse wheel (line deltas) scrolling
- Show a "Scrollback" badge at top-right when scrolled up from bottom

The 10,000-line scrollback buffer was already provided by `TermConfig::default()` — this adds the scroll UI to make it accessible.

Closes #311

## Test plan

- [ ] Open terminal, run `seq 200`, scroll wheel up — earlier lines visible
- [ ] Scroll wheel down — returns to bottom
- [ ] "Scrollback" badge appears when scrolled up, disappears at bottom
- [ ] New output auto-scrolls when already at bottom
- [ ] Trackpad smooth scroll works (pixel deltas)
- [ ] Mouse wheel discrete scroll works (line deltas)
- [ ] No crash on scroll with empty terminal (no history)