### PR TITLE
refactor: remove dead code from TerminalError enum

### DIFF
--- a/crates/kild-ui/src/terminal/errors.rs
+++ b/crates/kild-ui/src/terminal/errors.rs
@@ -1,16 +1,12 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-#[allow(dead_code)]
 pub enum TerminalError {
     #[error("Failed to open PTY: {message}")]
     PtyOpen { message: String },
 
     #[error("Failed to spawn shell '{shell}': {message}")]
     ShellSpawn { shell: String, message: String },
-
-    #[error("PTY read failed")]
-    PtyRead(#[source] std::io::Error),
 
     #[error("PTY write failed")]
     PtyWrite(#[source] std::io::Error),
@@ -21,33 +17,9 @@ pub enum TerminalError {
     #[error("Failed to acquire PTY writer lock: mutex poisoned")]
     WriterLockPoisoned,
 
-    #[error("Channel send failed: {0}")]
-    ChannelSend(String),
-
     #[error("Channels already taken (take_channels called more than once)")]
     ChannelsAlreadyTaken,
 
     #[error("PTY resize failed: {message}")]
     PtyResize { message: String },
-}
-
-#[allow(dead_code)]
-impl TerminalError {
-    pub fn error_code(&self) -> &'static str {
-        match self {
-            TerminalError::PtyOpen { .. } => "terminal.pty_open_failed",
-            TerminalError::ShellSpawn { .. } => "terminal.shell_spawn_failed",
-            TerminalError::PtyRead(_) => "terminal.pty_read_failed",
-            TerminalError::PtyWrite(_) => "terminal.pty_write_failed",
-            TerminalError::PtyFlush(_) => "terminal.pty_flush_failed",
-            TerminalError::WriterLockPoisoned => "terminal.writer_lock_poisoned",
-            TerminalError::ChannelSend(_) => "terminal.channel_send_failed",
-            TerminalError::ChannelsAlreadyTaken => "terminal.channels_already_taken",
-            TerminalError::PtyResize { .. } => "terminal.pty_resize_failed",
-        }
-    }
-
-    pub fn is_user_error(&self) -> bool {
-        false
-    }
 }


### PR DESCRIPTION
## Summary

- Remove unused `PtyRead` and `ChannelSend` variants from `TerminalError`
- Remove unused `impl TerminalError` block (`error_code()`, `is_user_error()`)
- Remove `#[allow(dead_code)]` attributes that were masking genuinely dead code

These were left over from before terminal rendering was wired up in #349. All 7 actively-used variants are preserved.

Closes #335