### PR TITLE
refactor: extract applescript_escape into shared escape module

### DIFF
--- a/crates/kild-core/src/escape.rs
+++ b/crates/kild-core/src/escape.rs
@@ -1,0 +1,22 @@
+//! Shared string escaping utilities.
+
+/// Escape a string for use in AppleScript.
+pub fn applescript_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_applescript_escape() {
+        assert_eq!(applescript_escape("hello"), "hello");
+        assert_eq!(applescript_escape("hello\"world"), "hello\\\"world");
+        assert_eq!(applescript_escape("hello\\world"), "hello\\\\world");
+        assert_eq!(applescript_escape("hello\nworld"), "hello\\nworld");
+    }
+}

--- a/crates/kild-core/src/git/health.rs
+++ b/crates/kild-core/src/git/health.rs
@@ -4,11 +4,7 @@ use git2::{Oid, Repository};
 use tracing::{debug, warn};
 
 use crate::git::naming::kild_branch_name;
-use crate::forge::types::{CiStatus, PrInfo};
-    use crate::git::types::{
-        BaseBranchDrift, BranchHealth, CommitActivity, ConflictStatus, DiffStats,
-        MergeReadiness, WorktreeStatus,
-    };
+use crate::git::types::{BaseBranchDrift, BranchHealth, CommitActivity, ConflictStatus, DiffStats};
 
 /// Find the merge base between two commits.
 ///
@@ -323,6 +319,8 @@ pub fn collect_branch_health(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::forge::types::{CiStatus, PrInfo};
+    use crate::git::types::{MergeReadiness, WorktreeStatus};
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;

--- a/crates/kild-core/src/lib.rs
+++ b/crates/kild-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod daemon;
 pub mod editor;
 pub mod errors;
+pub mod escape;
 pub mod events;
 pub mod files;
 pub mod forge;

--- a/crates/kild-core/src/notify/mod.rs
+++ b/crates/kild-core/src/notify/mod.rs
@@ -41,7 +41,7 @@ pub fn send_notification(title: &str, message: &str) {
 
 #[cfg(target_os = "macos")]
 fn send_platform_notification(title: &str, message: &str) {
-    use crate::terminal::common::escape::applescript_escape;
+    use crate::escape::applescript_escape;
 
     let escaped_title = applescript_escape(title);
     let escaped_message = applescript_escape(message);

--- a/crates/kild-core/src/terminal/backends/iterm.rs
+++ b/crates/kild-core/src/terminal/backends/iterm.rs
@@ -6,9 +6,10 @@ use crate::terminal::{common::detection::app_exists_macos, traits::TerminalBacke
 use crate::terminal::{errors::TerminalError, types::SpawnConfig};
 
 #[cfg(target_os = "macos")]
+use crate::escape::applescript_escape;
 use crate::terminal::common::{
     applescript::{close_applescript_window, execute_spawn_script, hide_applescript_window},
-    escape::{applescript_escape, build_cd_command},
+    escape::build_cd_command,
 };
 
 /// AppleScript template for iTerm window launching (with window ID capture).

--- a/crates/kild-core/src/terminal/backends/terminal_app.rs
+++ b/crates/kild-core/src/terminal/backends/terminal_app.rs
@@ -6,9 +6,10 @@ use crate::terminal::{common::detection::app_exists_macos, traits::TerminalBacke
 use crate::terminal::{errors::TerminalError, types::SpawnConfig};
 
 #[cfg(target_os = "macos")]
+use crate::escape::applescript_escape;
 use crate::terminal::common::{
     applescript::{close_applescript_window, execute_spawn_script, hide_applescript_window},
-    escape::{applescript_escape, build_cd_command},
+    escape::build_cd_command,
 };
 
 /// AppleScript template for Terminal.app window launching (with window ID capture).

--- a/crates/kild-core/src/terminal/common/escape.rs
+++ b/crates/kild-core/src/terminal/common/escape.rs
@@ -7,14 +7,6 @@ pub fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\"'\"'"))
 }
 
-/// Escape a string for use in AppleScript.
-pub fn applescript_escape(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-}
-
 /// Escape special regex characters for use in pkill -f pattern.
 pub fn escape_regex(s: &str) -> String {
     let mut result = String::with_capacity(s.len() * 2);
@@ -58,14 +50,6 @@ mod tests {
         assert_eq!(shell_escape("dir;rm -rf /"), "'dir;rm -rf /'");
         assert_eq!(shell_escape("$(whoami)"), "'$(whoami)'");
         assert_eq!(shell_escape("`id`"), "'`id`'");
-    }
-
-    #[test]
-    fn test_applescript_escape() {
-        assert_eq!(applescript_escape("hello"), "hello");
-        assert_eq!(applescript_escape("hello\"world"), "hello\\\"world");
-        assert_eq!(applescript_escape("hello\\world"), "hello\\\\world");
-        assert_eq!(applescript_escape("hello\nworld"), "hello\\nworld");
     }
 
     #[test]

--- a/crates/kild-core/src/terminal/operations.rs
+++ b/crates/kild-core/src/terminal/operations.rs
@@ -9,9 +9,8 @@ use tracing::debug;
 use tracing::warn;
 
 // Re-export common utilities for external use
-pub use crate::terminal::common::escape::{
-    applescript_escape, build_cd_command, escape_regex, shell_escape,
-};
+pub use crate::escape::applescript_escape;
+pub use crate::terminal::common::escape::{build_cd_command, escape_regex, shell_escape};
 
 /// Detect the available terminal.
 ///
@@ -272,14 +271,6 @@ mod tests {
         assert_eq!(shell_escape("hello"), "'hello'");
         assert_eq!(shell_escape("hello world"), "'hello world'");
         assert_eq!(shell_escape("hello'world"), "'hello'\"'\"'world'");
-    }
-
-    #[test]
-    fn test_applescript_escape() {
-        assert_eq!(applescript_escape("hello"), "hello");
-        assert_eq!(applescript_escape("hello\"world"), "hello\\\"world");
-        assert_eq!(applescript_escape("hello\\world"), "hello\\\\world");
-        assert_eq!(applescript_escape("hello\nworld"), "hello\\nworld");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Move `applescript_escape` from `terminal::common::escape` to a new top-level `escape` module in kild-core
- Eliminates cross-domain dependency where `notify` reached into `terminal` internals for a general-purpose string escaping function
- Fix pre-existing unused imports in `git/health.rs` exposed by `cargo fmt`

Closes #327

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes (803 tests)
- [x] `cargo build --all` succeeds