### PR TITLE
feat: harden async daemon client for production

### DIFF
--- a/crates/kild-ui/src/daemon_client.rs
+++ b/crates/kild-ui/src/daemon_client.rs
@@ -1,8 +1,10 @@
 //! Async daemon client using smol on GPUI's BackgroundExecutor.
 //!
 //! Provides IPC operations for communicating with the kild daemon:
-//! - `ping_daemon_async()` — Spike 1: simple roundtrip validation
+//! - `ping_daemon_async()` — check if daemon is running and responsive
 //! - `list_sessions_async()` / `find_first_running_session()` — session discovery
+//! - `get_session_async()` — query a single session by ID
+//! - `stop_session_async()` — stop a running daemon session
 //! - `connect_for_attach()` — two-connection attach for streaming PTY output
 //! - `send_write_stdin()` / `send_resize()` / `send_detach()` — write operations
 
@@ -10,7 +12,7 @@ use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use base64::Engine;
-use kild_protocol::{ClientMessage, DaemonMessage, SessionInfo, SessionStatus};
+use kild_protocol::{ClientMessage, DaemonMessage, ErrorCode, SessionInfo, SessionStatus};
 use smol::Async;
 use smol::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use thiserror::Error;
@@ -144,7 +146,7 @@ pub async fn ping_daemon_async() -> Result<bool, DaemonClientError> {
     };
 
     let request = ClientMessage::Ping {
-        id: "spike1-ping".to_string(),
+        id: next_request_id(),
     };
 
     // Write Ping as JSONL
@@ -217,12 +219,101 @@ pub async fn list_sessions_async() -> Result<Vec<SessionInfo>, DaemonClientError
 }
 
 /// Find the first Running daemon session.
+///
+/// Temporary convenience for the Ctrl+D toggle flow. Phase 3 (layout shell)
+/// replaces this with explicit sidebar-driven session selection.
 pub async fn find_first_running_session() -> Result<SessionInfo, DaemonClientError> {
     let sessions = list_sessions_async().await?;
     sessions
         .into_iter()
         .find(|s| s.status == SessionStatus::Running)
         .ok_or(DaemonClientError::SessionNotFound)
+}
+
+/// Query a single daemon session by ID.
+///
+/// Returns `Ok(Some(session))` if found, `Ok(None)` if the session doesn't
+/// exist in the daemon. Mirrors the sync client pattern from kild-core.
+#[allow(dead_code)]
+pub async fn get_session_async(session_id: &str) -> Result<Option<SessionInfo>, DaemonClientError> {
+    debug!(
+        event = "ui.daemon.get_session_started",
+        session_id = session_id
+    );
+
+    let mut stream = connect_to_daemon().await?;
+    let request = ClientMessage::GetSession {
+        id: next_request_id(),
+        session_id: session_id.to_string(),
+    };
+    send_message(&mut stream, &request).await?;
+
+    let mut reader = BufReader::new(stream);
+    let response = read_response(&mut reader).await?;
+
+    match response {
+        DaemonMessage::SessionInfo { session, .. } => {
+            info!(
+                event = "ui.daemon.get_session_completed",
+                session_id = session_id,
+                status = %session.status
+            );
+            Ok(Some(session))
+        }
+        DaemonMessage::Error {
+            code: ErrorCode::SessionNotFound,
+            ..
+        } => {
+            info!(
+                event = "ui.daemon.get_session_completed",
+                session_id = session_id,
+                result = "not_found"
+            );
+            Ok(None)
+        }
+        DaemonMessage::Error { code, message, .. } => Err(DaemonClientError::DaemonError {
+            code: code.to_string(),
+            message,
+        }),
+        other => Err(DaemonClientError::UnexpectedResponse(other)),
+    }
+}
+
+/// Stop a running daemon session.
+///
+/// Sends a stop command to the daemon, which kills the PTY process.
+/// Returns `Ok(())` on success, `Err` on failure.
+#[allow(dead_code)]
+pub async fn stop_session_async(session_id: &str) -> Result<(), DaemonClientError> {
+    debug!(
+        event = "ui.daemon.stop_session_started",
+        session_id = session_id
+    );
+
+    let mut stream = connect_to_daemon().await?;
+    let request = ClientMessage::StopSession {
+        id: next_request_id(),
+        session_id: session_id.to_string(),
+    };
+    send_message(&mut stream, &request).await?;
+
+    let mut reader = BufReader::new(stream);
+    let response = read_response(&mut reader).await?;
+
+    match response {
+        DaemonMessage::Ack { .. } => {
+            info!(
+                event = "ui.daemon.stop_session_completed",
+                session_id = session_id
+            );
+            Ok(())
+        }
+        DaemonMessage::Error { code, message, .. } => Err(DaemonClientError::DaemonError {
+            code: code.to_string(),
+            message,
+        }),
+        other => Err(DaemonClientError::UnexpectedResponse(other)),
+    }
 }
 
 /// Two-connection handle for attached daemon session.
@@ -350,4 +441,163 @@ pub async fn send_detach(
         session_id: session_id.to_string(),
     };
     send_message(writer, &msg).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use kild_protocol::{ClientMessage, DaemonMessage};
+
+    #[test]
+    fn test_next_request_id_increments() {
+        let id1 = next_request_id();
+        let id2 = next_request_id();
+        assert!(id1.starts_with("ui-"));
+        assert!(id2.starts_with("ui-"));
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_error_display_connection_closed() {
+        let err = DaemonClientError::ConnectionClosed;
+        assert_eq!(err.to_string(), "daemon closed connection (EOF)");
+    }
+
+    #[test]
+    fn test_error_display_session_not_found() {
+        let err = DaemonClientError::SessionNotFound;
+        assert_eq!(err.to_string(), "no running daemon session found");
+    }
+
+    #[test]
+    fn test_error_display_empty_response() {
+        let err = DaemonClientError::EmptyResponse;
+        assert_eq!(err.to_string(), "daemon sent empty response");
+    }
+
+    #[test]
+    fn test_error_display_daemon_error() {
+        let err = DaemonClientError::DaemonError {
+            code: "session_not_found".to_string(),
+            message: "no such session".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "daemon error (session_not_found): no such session"
+        );
+    }
+
+    #[test]
+    fn test_error_variants_are_distinct() {
+        let connect =
+            DaemonClientError::Connect(std::io::Error::new(std::io::ErrorKind::NotFound, "test"));
+        let closed = DaemonClientError::ConnectionClosed;
+        let empty = DaemonClientError::EmptyResponse;
+        let not_found = DaemonClientError::SessionNotFound;
+        assert_ne!(connect.to_string(), closed.to_string());
+        assert_ne!(empty.to_string(), not_found.to_string());
+    }
+
+    #[test]
+    fn test_client_message_serialization() {
+        let msg = ClientMessage::Ping {
+            id: "test-1".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"ping\""));
+        assert!(json.contains("\"id\":\"test-1\""));
+    }
+
+    #[test]
+    fn test_daemon_message_ack_parsing() {
+        let json = r#"{"type":"ack","id":"test-1"}"#;
+        let msg: DaemonMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, DaemonMessage::Ack { .. }));
+    }
+
+    #[test]
+    fn test_pty_output_parsing_with_base64() {
+        let json = r#"{"type":"pty_output","session_id":"test","data":"aGVsbG8="}"#;
+        let msg: DaemonMessage = serde_json::from_str(json).unwrap();
+        if let DaemonMessage::PtyOutput { data, session_id } = msg {
+            assert_eq!(session_id, "test");
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(&data)
+                .unwrap();
+            assert_eq!(decoded, b"hello");
+        } else {
+            panic!("expected PtyOutput");
+        }
+    }
+
+    #[test]
+    fn test_error_response_parsing() {
+        let json = r#"{"type":"error","id":"req-1","code":"session_not_found","message":"no such session"}"#;
+        let msg: DaemonMessage = serde_json::from_str(json).unwrap();
+        if let DaemonMessage::Error { code, message, .. } = msg {
+            assert_eq!(code, ErrorCode::SessionNotFound);
+            assert_eq!(message, "no such session");
+        } else {
+            panic!("expected Error");
+        }
+    }
+
+    #[test]
+    fn test_write_stdin_base64_roundtrip() {
+        let data = b"hello world";
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+        let msg = ClientMessage::WriteStdin {
+            id: "test".to_string(),
+            session_id: "sess".to_string(),
+            data: encoded.clone(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(&encoded));
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        if let ClientMessage::WriteStdin { data: d, .. } = parsed {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(&d)
+                .unwrap();
+            assert_eq!(decoded, b"hello world");
+        } else {
+            panic!("expected WriteStdin");
+        }
+    }
+
+    #[test]
+    fn test_get_session_message_roundtrip() {
+        let msg = ClientMessage::GetSession {
+            id: "ui-42".to_string(),
+            session_id: "myapp_feature-auth".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"get_session\""));
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id(), "ui-42");
+    }
+
+    #[test]
+    fn test_stop_session_message_roundtrip() {
+        let msg = ClientMessage::StopSession {
+            id: "ui-43".to_string(),
+            session_id: "myapp_feature-auth".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"stop_session\""));
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id(), "ui-43");
+    }
+
+    #[test]
+    fn test_session_info_response_parsing() {
+        let json = r#"{"type":"session_info","id":"req-1","session":{"id":"test-sess","working_directory":"/tmp","command":"bash","status":"running","created_at":"2026-02-12T00:00:00Z"}}"#;
+        let msg: DaemonMessage = serde_json::from_str(json).unwrap();
+        if let DaemonMessage::SessionInfo { session, .. } = msg {
+            assert_eq!(session.id, "test-sess");
+            assert_eq!(session.status, SessionStatus::Running);
+        } else {
+            panic!("expected SessionInfo");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Clean up spike artifacts in `daemon_client.rs` — replace hardcoded `"spike1-ping"` request ID with `next_request_id()`, update module/function docs to remove spike references
- Add `get_session_async()` and `stop_session_async()` operations for Phase 2 P2+ consumers (layout shell, sidebar)
- Add 14 unit tests covering request ID generation, error display variants, message serialization/parsing, base64 roundtrips, and response parsing

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] `cargo test -p kild-ui -- daemon_client` — 14 tests pass
- [x] `cargo test --all` — 174+ tests pass, no regressions
- [x] `cargo build --all` — clean build