### PR TITLE
fix(ui): handle Cmd+nav and Alt+nav key combos in terminal

### DIFF
--- a/crates/kild-ui/src/terminal/input.rs
+++ b/crates/kild-ui/src/terminal/input.rs
@@ -39,6 +39,7 @@ pub fn keystroke_to_escape(keystroke: &Keystroke, app_cursor_mode: bool) -> Opti
     if alt {
         match key {
             "backspace" => return Some(vec![0x1b, 0x7f]), // ESC DEL: delete word backward
+            "delete" => return Some(vec![0x1b, b'd']),    // ESC d: delete word forward
             "left" => return Some(vec![0x1b, b'b']),      // ESC b: word backward
             "right" => return Some(vec![0x1b, b'f']),     // ESC f: word forward
             _ => {} // Fall through to printable Alt+key handler
@@ -392,6 +393,14 @@ mod tests {
         assert_eq!(
             keystroke_to_escape(&alt_key("left"), false),
             Some(vec![0x1b, b'b'])
+        );
+    }
+
+    #[test]
+    fn test_alt_delete_deletes_word_forward() {
+        assert_eq!(
+            keystroke_to_escape(&alt_key("delete"), false),
+            Some(vec![0x1b, b'd'])
         );
     }
 


### PR DESCRIPTION
## Summary

- Add Cmd+Backspace/Delete/Left/Right for line-level navigation and deletion (Ctrl+U/K/A/E)
- Add Alt+Backspace/Left/Right for word-level navigation and deletion (ESC DEL/b/f)
- Matches standard macOS terminal behavior (iTerm2, Terminal.app, Ghostty)

## Test plan

- [x] 8 new unit tests covering all modifier combos
- [x] Existing Cmd+J/K/D reservation tests still pass
- [x] Alt+printable char (e.g. Alt+b) not regressed
- [x] Full suite: `cargo fmt --check && cargo clippy --all -- -D warnings && cargo test --all && cargo build --all`