### PR TITLE
feat(ui): surface agent teams in kild UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kild-teams"
+version = "0.1.0"
+dependencies = [
+ "dirs 5.0.1",
+ "notify 8.2.0",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "kild-tmux-shim"
 version = "0.1.0"
 dependencies = [
@@ -3503,6 +3516,7 @@ dependencies = [
  "gpui-component",
  "kild-core",
  "kild-protocol",
+ "kild-teams",
  "linkify",
  "notify 8.2.0",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ kild-core = { path = "crates/kild-core" }
 kild-daemon = { path = "crates/kild-daemon" }
 kild-peek-core = { path = "crates/kild-peek-core" }
 kild-protocol = { path = "crates/kild-protocol" }
+kild-teams = { path = "crates/kild-teams" }
 
 # UI dependencies
 gpui = "0.2"

--- a/crates/kild-teams/Cargo.toml
+++ b/crates/kild-teams/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "kild-teams"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Agent team discovery and state management for KILD UI"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+dirs = { workspace = true }
+notify = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/kild-teams/src/discovery.rs
+++ b/crates/kild-teams/src/discovery.rs
@@ -1,0 +1,206 @@
+//! Fallback teammate discovery from shim pane registry.
+//!
+//! When no Claude Code team config exists, discovers teammates directly
+//! from the shim `panes.json`. Less rich than team config (no agent_type,
+//! no agent_id) but sufficient for basic UI integration.
+
+use std::path::PathBuf;
+
+use crate::errors::TeamsError;
+use crate::parser;
+use crate::types::{TeamColor, TeamMember};
+
+/// Default shim state directory: `~/.kild/shim/`.
+fn shim_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".kild").join("shim"))
+}
+
+/// Discover teammates from the shim pane registry for a session.
+///
+/// Returns `None` if the registry doesn't exist or has only the leader pane.
+/// `%0` is treated as the leader; all others are teammates.
+pub fn discover_teammates(session_id: &str) -> Result<Option<Vec<TeamMember>>, TeamsError> {
+    let Some(base) = shim_dir() else {
+        return Ok(None);
+    };
+    let registry_path = base.join(session_id).join("panes.json");
+    discover_teammates_from_path(&registry_path)
+}
+
+/// Discover teammates from a specific registry path (for testing).
+pub fn discover_teammates_from_path(
+    registry_path: &std::path::Path,
+) -> Result<Option<Vec<TeamMember>>, TeamsError> {
+    let registry = match parser::parse_shim_registry(registry_path)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+
+    // Only leader pane — no teammates
+    if registry.panes.len() <= 1 {
+        return Ok(None);
+    }
+
+    let mut members: Vec<TeamMember> = registry
+        .panes
+        .iter()
+        .filter(|(_, pane)| !pane.hidden)
+        .map(|(pane_id, pane)| {
+            let is_leader = pane_id == "%0";
+            let name = if pane.title.is_empty() {
+                if is_leader {
+                    "leader".to_string()
+                } else {
+                    format!("teammate-{}", pane_id.trim_start_matches('%'))
+                }
+            } else {
+                pane.title.clone()
+            };
+
+            let color = TeamColor::from_border_style(&pane.border_style);
+
+            TeamMember {
+                name,
+                agent_id: String::new(),
+                agent_type: String::new(),
+                color,
+                pane_id: pane_id.clone(),
+                daemon_session_id: Some(pane.daemon_session_id.clone()),
+                is_active: true,
+                is_leader,
+            }
+        })
+        .collect();
+
+    // Sort by pane_id for stable ordering (%0, %1, %2, ...)
+    members.sort_by(|a, b| a.pane_id.cmp(&b.pane_id));
+
+    Ok(Some(members))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_discover_basic() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("panes.json");
+
+        fs::write(
+            &path,
+            r#"{
+                "panes": {
+                    "%0": { "daemon_session_id": "d-0", "title": "", "border_style": "" },
+                    "%1": { "daemon_session_id": "d-1", "title": "researcher", "border_style": "fg=blue" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let members = discover_teammates_from_path(&path).unwrap().unwrap();
+        assert_eq!(members.len(), 2);
+
+        // Leader
+        assert_eq!(members[0].pane_id, "%0");
+        assert!(members[0].is_leader);
+        assert_eq!(members[0].name, "leader");
+        assert_eq!(members[0].daemon_session_id.as_deref(), Some("d-0"));
+
+        // Teammate
+        assert_eq!(members[1].pane_id, "%1");
+        assert!(!members[1].is_leader);
+        assert_eq!(members[1].name, "researcher");
+        assert_eq!(members[1].color, TeamColor::Blue);
+        assert_eq!(members[1].daemon_session_id.as_deref(), Some("d-1"));
+    }
+
+    #[test]
+    fn test_discover_leader_only() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("panes.json");
+
+        fs::write(
+            &path,
+            r#"{ "panes": { "%0": { "daemon_session_id": "d-0", "title": "" } } }"#,
+        )
+        .unwrap();
+
+        // Only leader — no team
+        assert!(discover_teammates_from_path(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_discover_title_as_name() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("panes.json");
+
+        fs::write(
+            &path,
+            r#"{
+                "panes": {
+                    "%0": { "daemon_session_id": "d-0", "title": "main-agent" },
+                    "%1": { "daemon_session_id": "d-1", "title": "" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let members = discover_teammates_from_path(&path).unwrap().unwrap();
+        assert_eq!(members[0].name, "main-agent"); // title used
+        assert_eq!(members[1].name, "teammate-1"); // fallback
+    }
+
+    #[test]
+    fn test_discover_color_parsing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("panes.json");
+
+        fs::write(
+            &path,
+            r#"{
+                "panes": {
+                    "%0": { "daemon_session_id": "d-0", "title": "", "border_style": "" },
+                    "%1": { "daemon_session_id": "d-1", "title": "a", "border_style": "fg=red" },
+                    "%2": { "daemon_session_id": "d-2", "title": "b", "border_style": "fg=cyan" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let members = discover_teammates_from_path(&path).unwrap().unwrap();
+        assert_eq!(members[0].color, TeamColor::Unknown); // leader, no style
+        assert_eq!(members[1].color, TeamColor::Red);
+        assert_eq!(members[2].color, TeamColor::Cyan);
+    }
+
+    #[test]
+    fn test_discover_hidden_panes_skipped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("panes.json");
+
+        fs::write(
+            &path,
+            r#"{
+                "panes": {
+                    "%0": { "daemon_session_id": "d-0", "title": "", "hidden": false },
+                    "%1": { "daemon_session_id": "d-1", "title": "visible", "hidden": false },
+                    "%2": { "daemon_session_id": "d-2", "title": "hidden", "hidden": true }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let members = discover_teammates_from_path(&path).unwrap().unwrap();
+        assert_eq!(members.len(), 2);
+        assert!(members.iter().all(|m| m.name != "hidden"));
+    }
+
+    #[test]
+    fn test_discover_missing_registry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("nonexistent.json");
+        assert!(discover_teammates_from_path(&path).unwrap().is_none());
+    }
+}

--- a/crates/kild-teams/src/errors.rs
+++ b/crates/kild-teams/src/errors.rs
@@ -1,0 +1,13 @@
+//! Error types for kild-teams.
+
+#[derive(Debug, thiserror::Error)]
+pub enum TeamsError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("teams error: {message}")]
+    Teams { message: String },
+}

--- a/crates/kild-teams/src/lib.rs
+++ b/crates/kild-teams/src/lib.rs
@@ -1,0 +1,18 @@
+//! Agent team discovery and state management for KILD UI.
+//!
+//! Standalone library that understands Claude Code agent teams.
+//! Reads team configs from `~/.claude/teams/` and cross-references
+//! with shim pane registries at `~/.kild/shim/` to map teammates
+//! to daemon PTY sessions.
+
+pub mod discovery;
+pub mod errors;
+pub mod mapper;
+pub mod parser;
+pub mod scanner;
+pub mod types;
+pub mod watcher;
+
+pub use errors::TeamsError;
+pub use types::*;
+pub use watcher::TeamWatcher;

--- a/crates/kild-teams/src/mapper.rs
+++ b/crates/kild-teams/src/mapper.rs
@@ -1,0 +1,229 @@
+//! Cross-reference team config with shim pane registry.
+//!
+//! Enriches `TeamMember` entries with `daemon_session_id` by reading
+//! the shim pane registry for a given kild session.
+
+use std::path::PathBuf;
+
+use crate::errors::TeamsError;
+use crate::parser;
+use crate::types::TeamState;
+
+/// Default shim state directory: `~/.kild/shim/`.
+fn shim_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".kild").join("shim"))
+}
+
+/// Resolve a shim pane registry path for a session.
+fn shim_registry_path(session_id: &str) -> Option<PathBuf> {
+    shim_dir().map(|d| d.join(session_id).join("panes.json"))
+}
+
+/// Enrich team state with daemon session IDs from the shim pane registry.
+///
+/// For each member, looks up their `pane_id` in the registry and copies
+/// the `daemon_session_id`. Members with no matching pane keep `None`.
+pub fn resolve_team(mut team_state: TeamState, session_id: &str) -> Result<TeamState, TeamsError> {
+    let Some(registry_path) = shim_registry_path(session_id) else {
+        tracing::debug!(
+            event = "teams.mapper.home_dir_unavailable",
+            session_id = session_id
+        );
+        return Ok(team_state);
+    };
+
+    let registry = match parser::parse_shim_registry(&registry_path)? {
+        Some(r) => r,
+        None => {
+            tracing::debug!(
+                event = "teams.mapper.no_shim_registry",
+                session_id = session_id,
+                path = %registry_path.display()
+            );
+            return Ok(team_state);
+        }
+    };
+
+    team_state.kild_session_id = Some(session_id.to_string());
+
+    for member in &mut team_state.members {
+        if let Some(pane) = registry.panes.get(&member.pane_id) {
+            member.daemon_session_id = Some(pane.daemon_session_id.clone());
+            tracing::debug!(
+                event = "teams.mapper.pane_resolved",
+                member = member.name,
+                pane_id = member.pane_id,
+                daemon_session_id = pane.daemon_session_id
+            );
+        } else {
+            tracing::debug!(
+                event = "teams.mapper.pane_not_found",
+                member = member.name,
+                pane_id = member.pane_id,
+                session_id = session_id
+            );
+        }
+    }
+
+    Ok(team_state)
+}
+
+/// Resolve team state from a registry at a custom path (for testing).
+pub fn resolve_team_with_registry(
+    mut team_state: TeamState,
+    registry_path: &std::path::Path,
+    session_id: &str,
+) -> Result<TeamState, TeamsError> {
+    let registry = match parser::parse_shim_registry(registry_path)? {
+        Some(r) => r,
+        None => return Ok(team_state),
+    };
+
+    team_state.kild_session_id = Some(session_id.to_string());
+
+    for member in &mut team_state.members {
+        if let Some(pane) = registry.panes.get(&member.pane_id) {
+            member.daemon_session_id = Some(pane.daemon_session_id.clone());
+        }
+    }
+
+    Ok(team_state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{TeamColor, TeamMember};
+    use std::fs;
+
+    fn make_team(members: Vec<TeamMember>) -> TeamState {
+        TeamState {
+            team_name: "test-team".to_string(),
+            kild_session_id: None,
+            members,
+        }
+    }
+
+    fn make_member(name: &str, pane_id: &str, is_leader: bool) -> TeamMember {
+        TeamMember {
+            name: name.to_string(),
+            agent_id: format!("{}@test-team", name),
+            agent_type: "general-purpose".to_string(),
+            color: TeamColor::Blue,
+            pane_id: pane_id.to_string(),
+            daemon_session_id: None,
+            is_active: true,
+            is_leader,
+        }
+    }
+
+    #[test]
+    fn test_resolve_all_mapped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let registry_path = dir.path().join("panes.json");
+
+        fs::write(
+            &registry_path,
+            r#"{
+                "panes": {
+                    "%0": { "daemon_session_id": "d-leader", "title": "", "border_style": "" },
+                    "%1": { "daemon_session_id": "d-worker1", "title": "worker1", "border_style": "fg=blue" },
+                    "%2": { "daemon_session_id": "d-worker2", "title": "worker2", "border_style": "fg=red" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let team = make_team(vec![
+            make_member("leader", "%0", true),
+            make_member("worker1", "%1", false),
+            make_member("worker2", "%2", false),
+        ]);
+
+        let resolved = resolve_team_with_registry(team, &registry_path, "sess-123").unwrap();
+
+        assert_eq!(resolved.kild_session_id.as_deref(), Some("sess-123"));
+        assert_eq!(
+            resolved.members[0].daemon_session_id.as_deref(),
+            Some("d-leader")
+        );
+        assert_eq!(
+            resolved.members[1].daemon_session_id.as_deref(),
+            Some("d-worker1")
+        );
+        assert_eq!(
+            resolved.members[2].daemon_session_id.as_deref(),
+            Some("d-worker2")
+        );
+    }
+
+    #[test]
+    fn test_resolve_missing_pane() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let registry_path = dir.path().join("panes.json");
+
+        fs::write(
+            &registry_path,
+            r#"{ "panes": { "%0": { "daemon_session_id": "d-1", "title": "" } } }"#,
+        )
+        .unwrap();
+
+        let team = make_team(vec![
+            make_member("leader", "%0", true),
+            make_member("ghost", "%99", false),
+        ]);
+
+        let resolved = resolve_team_with_registry(team, &registry_path, "sess").unwrap();
+
+        assert_eq!(
+            resolved.members[0].daemon_session_id.as_deref(),
+            Some("d-1")
+        );
+        assert!(resolved.members[1].daemon_session_id.is_none());
+    }
+
+    #[test]
+    fn test_resolve_empty_members() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let registry_path = dir.path().join("panes.json");
+
+        fs::write(&registry_path, r#"{ "panes": {} }"#).unwrap();
+
+        let team = make_team(vec![]);
+        let resolved = resolve_team_with_registry(team, &registry_path, "sess").unwrap();
+
+        assert!(resolved.members.is_empty());
+        assert_eq!(resolved.kild_session_id.as_deref(), Some("sess"));
+    }
+
+    #[test]
+    fn test_resolve_missing_registry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let registry_path = dir.path().join("nonexistent.json");
+
+        let team = make_team(vec![make_member("a", "%0", true)]);
+        let resolved = resolve_team_with_registry(team, &registry_path, "sess").unwrap();
+
+        // No daemon session IDs resolved, but no error
+        assert!(resolved.members[0].daemon_session_id.is_none());
+        assert!(resolved.kild_session_id.is_none());
+    }
+
+    #[test]
+    fn test_resolve_leader_no_pane_id() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let registry_path = dir.path().join("panes.json");
+
+        fs::write(
+            &registry_path,
+            r#"{ "panes": { "%0": { "daemon_session_id": "d-1", "title": "" } } }"#,
+        )
+        .unwrap();
+
+        // Leader with empty pane_id won't match any registry entry
+        let team = make_team(vec![make_member("leader", "", true)]);
+        let resolved = resolve_team_with_registry(team, &registry_path, "sess").unwrap();
+
+        assert!(resolved.members[0].daemon_session_id.is_none());
+    }
+}

--- a/crates/kild-teams/src/parser.rs
+++ b/crates/kild-teams/src/parser.rs
@@ -1,0 +1,341 @@
+//! Parsers for Claude Code team config and shim pane registry.
+//!
+//! Raw serde types with `#[serde(default)]` for forward compatibility
+//! with unknown/added fields.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::errors::TeamsError;
+use crate::types::{TeamColor, TeamMember, TeamState};
+
+// =============================================================================
+// Claude Code team config: ~/.claude/teams/<team>/config.json
+// =============================================================================
+
+/// Raw Claude Code team config (serde).
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct RawTeamConfig {
+    pub members: Vec<RawTeamMember>,
+    #[serde(rename = "hiddenPaneIds")]
+    pub hidden_pane_ids: Vec<String>,
+}
+
+/// Raw Claude Code team member entry (serde).
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct RawTeamMember {
+    #[serde(rename = "agentId")]
+    pub agent_id: String,
+    pub name: String,
+    #[serde(rename = "agentType")]
+    pub agent_type: String,
+    pub model: String,
+    pub color: String,
+    #[serde(rename = "planModeRequired")]
+    pub plan_mode_required: bool,
+    #[serde(rename = "joinedAt")]
+    pub joined_at: u64,
+    #[serde(rename = "tmuxPaneId")]
+    pub tmux_pane_id: String,
+    pub cwd: String,
+    #[serde(rename = "backendType")]
+    pub backend_type: String,
+    #[serde(rename = "isActive")]
+    pub is_active: bool,
+}
+
+// =============================================================================
+// Shim pane registry: ~/.kild/shim/<session_id>/panes.json
+// (Duplicates minimal fields from kild-tmux-shim to avoid dependency)
+// =============================================================================
+
+/// Minimal shim pane registry for cross-referencing.
+#[derive(Debug, Deserialize)]
+pub struct ShimPaneRegistry {
+    pub panes: HashMap<String, ShimPaneEntry>,
+}
+
+/// Minimal pane entry — only fields we need for mapping.
+#[derive(Debug, Deserialize)]
+pub struct ShimPaneEntry {
+    pub daemon_session_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub border_style: String,
+    #[serde(default)]
+    pub hidden: bool,
+}
+
+// =============================================================================
+// Parse functions
+// =============================================================================
+
+/// Parse a Claude Code team config file.
+///
+/// Returns `Ok(None)` for missing file, `Err` for malformed JSON.
+pub fn parse_team_config(path: &Path) -> Result<Option<TeamState>, TeamsError> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+
+    let raw: RawTeamConfig = serde_json::from_str(&content)?;
+
+    // Derive team name from directory name
+    let team_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let members = raw
+        .members
+        .into_iter()
+        .map(|m| {
+            let is_leader = m.tmux_pane_id.is_empty() || m.tmux_pane_id == "%0";
+            TeamMember {
+                name: m.name,
+                agent_id: m.agent_id,
+                agent_type: m.agent_type,
+                color: TeamColor::parse(&m.color),
+                pane_id: m.tmux_pane_id,
+                daemon_session_id: None,
+                is_active: m.is_active,
+                is_leader,
+            }
+        })
+        .collect();
+
+    Ok(Some(TeamState {
+        team_name,
+        kild_session_id: None,
+        members,
+    }))
+}
+
+/// Parse a shim pane registry file.
+///
+/// Returns `Ok(None)` for missing file, `Err` for malformed JSON.
+pub fn parse_shim_registry(path: &Path) -> Result<Option<ShimPaneRegistry>, TeamsError> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+
+    let registry: ShimPaneRegistry = serde_json::from_str(&content)?;
+    Ok(Some(registry))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_parse_team_config_valid() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let team_dir = dir.path().join("my-team");
+        fs::create_dir_all(&team_dir).unwrap();
+        let config_path = team_dir.join("config.json");
+
+        fs::write(
+            &config_path,
+            r#"{
+                "members": [
+                    {
+                        "agentId": "researcher@my-team",
+                        "name": "researcher",
+                        "agentType": "general-purpose",
+                        "model": "claude-sonnet-4-5-20250929",
+                        "color": "blue",
+                        "planModeRequired": false,
+                        "joinedAt": 1707500000000,
+                        "tmuxPaneId": "%1",
+                        "cwd": "/project",
+                        "backendType": "tmux",
+                        "isActive": true
+                    }
+                ],
+                "hiddenPaneIds": []
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_team_config(&config_path).unwrap().unwrap();
+        assert_eq!(result.team_name, "my-team");
+        assert_eq!(result.members.len(), 1);
+        assert_eq!(result.members[0].name, "researcher");
+        assert_eq!(result.members[0].color, TeamColor::Blue);
+        assert_eq!(result.members[0].pane_id, "%1");
+        assert!(result.members[0].is_active);
+        assert!(!result.members[0].is_leader);
+    }
+
+    #[test]
+    fn test_parse_team_config_leader_detection() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let team_dir = dir.path().join("team");
+        fs::create_dir_all(&team_dir).unwrap();
+        let config_path = team_dir.join("config.json");
+
+        // Leader has empty tmuxPaneId
+        fs::write(
+            &config_path,
+            r#"{
+                "members": [
+                    { "name": "leader", "tmuxPaneId": "" },
+                    { "name": "worker", "tmuxPaneId": "%1" }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_team_config(&config_path).unwrap().unwrap();
+        assert!(result.members[0].is_leader);
+        assert!(!result.members[1].is_leader);
+    }
+
+    #[test]
+    fn test_parse_team_config_leader_pane_zero() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let team_dir = dir.path().join("team");
+        fs::create_dir_all(&team_dir).unwrap();
+        let config_path = team_dir.join("config.json");
+
+        fs::write(
+            &config_path,
+            r#"{ "members": [{ "name": "leader", "tmuxPaneId": "%0" }] }"#,
+        )
+        .unwrap();
+
+        let result = parse_team_config(&config_path).unwrap().unwrap();
+        assert!(result.members[0].is_leader);
+    }
+
+    #[test]
+    fn test_parse_team_config_minimal_fields() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let team_dir = dir.path().join("team");
+        fs::create_dir_all(&team_dir).unwrap();
+        let config_path = team_dir.join("config.json");
+
+        // Only required structure, all fields default
+        fs::write(&config_path, r#"{ "members": [{}] }"#).unwrap();
+
+        let result = parse_team_config(&config_path).unwrap().unwrap();
+        assert_eq!(result.members.len(), 1);
+        assert_eq!(result.members[0].name, "");
+        assert_eq!(result.members[0].color, TeamColor::Unknown);
+        assert!(result.members[0].is_leader); // empty pane_id = leader
+    }
+
+    #[test]
+    fn test_parse_team_config_extra_unknown_fields() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let team_dir = dir.path().join("team");
+        fs::create_dir_all(&team_dir).unwrap();
+        let config_path = team_dir.join("config.json");
+
+        fs::write(
+            &config_path,
+            r#"{
+                "members": [{ "name": "a", "futureField": 42 }],
+                "hiddenPaneIds": [],
+                "anotherNewField": "hello"
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_team_config(&config_path).unwrap().unwrap();
+        assert_eq!(result.members.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_team_config_missing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("nonexistent.json");
+        let result = parse_team_config(&path).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_team_config_malformed_json() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, "not valid json{{{").unwrap();
+        assert!(parse_team_config(&path).is_err());
+    }
+
+    #[test]
+    fn test_parse_team_config_empty_members() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let team_dir = dir.path().join("team");
+        fs::create_dir_all(&team_dir).unwrap();
+        let config_path = team_dir.join("config.json");
+
+        fs::write(&config_path, r#"{ "members": [] }"#).unwrap();
+
+        let result = parse_team_config(&config_path).unwrap().unwrap();
+        assert!(result.members.is_empty());
+    }
+
+    #[test]
+    fn test_parse_shim_registry_valid() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("panes.json");
+
+        fs::write(
+            &path,
+            r#"{
+                "next_pane_id": 2,
+                "session_name": "kild_0",
+                "panes": {
+                    "%0": {
+                        "daemon_session_id": "d-1",
+                        "title": "",
+                        "border_style": "",
+                        "window_id": "0",
+                        "hidden": false
+                    },
+                    "%1": {
+                        "daemon_session_id": "d-2",
+                        "title": "researcher",
+                        "border_style": "fg=blue",
+                        "window_id": "0",
+                        "hidden": false
+                    }
+                },
+                "windows": { "0": { "name": "main", "pane_ids": ["%0", "%1"] } },
+                "sessions": {}
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_shim_registry(&path).unwrap().unwrap();
+        assert_eq!(result.panes.len(), 2);
+        assert_eq!(result.panes["%0"].daemon_session_id, "d-1");
+        assert_eq!(result.panes["%1"].title, "researcher");
+    }
+
+    #[test]
+    fn test_parse_shim_registry_missing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+        assert!(parse_shim_registry(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_parse_shim_registry_malformed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("panes.json");
+        fs::write(&path, "garbage").unwrap();
+        assert!(parse_shim_registry(&path).is_err());
+    }
+}

--- a/crates/kild-teams/src/scanner.rs
+++ b/crates/kild-teams/src/scanner.rs
@@ -1,0 +1,158 @@
+//! Scan for Claude Code team configs on disk.
+//!
+//! Enumerates `~/.claude/teams/*/config.json` to find active teams.
+
+use std::path::{Path, PathBuf};
+
+use crate::parser;
+use crate::types::TeamState;
+
+/// Default teams directory: `~/.claude/teams/`.
+pub fn default_teams_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude").join("teams"))
+}
+
+/// Scan a teams directory for all team configs.
+///
+/// Returns `(team_name, TeamState)` pairs for each successfully parsed config.
+/// Silently skips directories with missing or malformed config files.
+pub fn scan_teams(teams_dir: &Path) -> Vec<(String, TeamState)> {
+    let entries = match std::fs::read_dir(teams_dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                event = "teams.scanner.read_dir_failed",
+                path = %teams_dir.display(),
+                error = %e
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut teams = Vec::new();
+
+    for entry in entries {
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        let config_path = path.join("config.json");
+        match parser::parse_team_config(&config_path) {
+            Ok(Some(state)) => {
+                tracing::debug!(
+                    event = "teams.scanner.team_found",
+                    team = state.team_name,
+                    members = state.members.len()
+                );
+                teams.push((state.team_name.clone(), state));
+            }
+            Ok(None) => {
+                // No config.json in this directory, skip
+            }
+            Err(e) => {
+                tracing::warn!(
+                    event = "teams.scanner.parse_failed",
+                    path = %config_path.display(),
+                    error = %e
+                );
+            }
+        }
+    }
+
+    teams
+}
+
+/// Scan the default teams directory (`~/.claude/teams/`).
+pub fn scan_teams_default() -> Vec<(String, TeamState)> {
+    match default_teams_dir() {
+        Some(dir) => scan_teams(&dir),
+        None => {
+            tracing::debug!(
+                event = "teams.scanner.home_dir_unavailable",
+                "Cannot determine home directory"
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_scan_teams_empty_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let teams = scan_teams(dir.path());
+        assert!(teams.is_empty());
+    }
+
+    #[test]
+    fn test_scan_teams_with_teams() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Create two team directories with config
+        for name in &["team-alpha", "team-beta"] {
+            let team_dir = dir.path().join(name);
+            fs::create_dir_all(&team_dir).unwrap();
+            fs::write(
+                team_dir.join("config.json"),
+                r#"{ "members": [{ "name": "worker", "tmuxPaneId": "%1" }] }"#,
+            )
+            .unwrap();
+        }
+
+        let teams = scan_teams(dir.path());
+        assert_eq!(teams.len(), 2);
+
+        let names: Vec<&str> = teams.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"team-alpha"));
+        assert!(names.contains(&"team-beta"));
+    }
+
+    #[test]
+    fn test_scan_teams_ignores_non_dirs() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Create a regular file (not a directory)
+        fs::write(dir.path().join("not-a-team.txt"), "hello").unwrap();
+
+        let teams = scan_teams(dir.path());
+        assert!(teams.is_empty());
+    }
+
+    #[test]
+    fn test_scan_teams_missing_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let missing = dir.path().join("nonexistent");
+
+        let teams = scan_teams(&missing);
+        assert!(teams.is_empty());
+    }
+
+    #[test]
+    fn test_scan_teams_skips_malformed() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Valid team
+        let good = dir.path().join("good-team");
+        fs::create_dir_all(&good).unwrap();
+        fs::write(
+            good.join("config.json"),
+            r#"{ "members": [{ "name": "a" }] }"#,
+        )
+        .unwrap();
+
+        // Malformed team
+        let bad = dir.path().join("bad-team");
+        fs::create_dir_all(&bad).unwrap();
+        fs::write(bad.join("config.json"), "not json").unwrap();
+
+        let teams = scan_teams(dir.path());
+        assert_eq!(teams.len(), 1);
+        assert_eq!(teams[0].0, "good-team");
+    }
+}

--- a/crates/kild-teams/src/types.rs
+++ b/crates/kild-teams/src/types.rs
@@ -1,0 +1,99 @@
+//! Domain types for agent team state.
+//!
+//! Our own types decoupled from Claude Code's JSON format. Raw serde types
+//! for Claude Code config are in `parser.rs`.
+
+use serde::{Deserialize, Serialize};
+
+/// Color assigned to a team member by Claude Code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TeamColor {
+    Red,
+    Blue,
+    Green,
+    Yellow,
+    Purple,
+    Orange,
+    Pink,
+    Cyan,
+    Unknown,
+}
+
+impl TeamColor {
+    /// Parse a color from Claude Code's string format (e.g., "blue", "magenta").
+    pub fn parse(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "red" => Self::Red,
+            "blue" => Self::Blue,
+            "green" => Self::Green,
+            "yellow" => Self::Yellow,
+            "purple" | "magenta" => Self::Purple,
+            "orange" | "colour208" => Self::Orange,
+            "pink" | "colour205" => Self::Pink,
+            "cyan" => Self::Cyan,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Parse from a tmux border_style string like "fg=blue".
+    pub fn from_border_style(style: &str) -> Self {
+        let color = style
+            .split(',')
+            .find_map(|part| part.strip_prefix("fg="))
+            .unwrap_or("");
+        Self::parse(color)
+    }
+}
+
+/// A single member of an agent team.
+#[derive(Debug, Clone)]
+pub struct TeamMember {
+    /// Display name (e.g., "researcher").
+    pub name: String,
+    /// Unique agent ID (e.g., "researcher@my-team").
+    pub agent_id: String,
+    /// Agent type (e.g., "general-purpose").
+    pub agent_type: String,
+    /// Color assigned by Claude Code.
+    pub color: TeamColor,
+    /// Tmux pane ID (e.g., "%1").
+    pub pane_id: String,
+    /// Daemon session ID resolved from shim registry.
+    pub daemon_session_id: Option<String>,
+    /// Whether the member is currently active.
+    pub is_active: bool,
+    /// Whether this member is the team leader.
+    pub is_leader: bool,
+}
+
+/// State of an agent team associated with a kild session.
+#[derive(Debug, Clone)]
+pub struct TeamState {
+    /// Team name (directory name under `~/.claude/teams/`).
+    pub team_name: String,
+    /// Kild session ID this team belongs to (resolved from shim).
+    pub kild_session_id: Option<String>,
+    /// Team members including the leader.
+    pub members: Vec<TeamMember>,
+}
+
+impl TeamState {
+    /// Get all non-leader members (teammates).
+    pub fn teammates(&self) -> impl Iterator<Item = &TeamMember> {
+        self.members.iter().filter(|m| !m.is_leader)
+    }
+
+    /// Get the leader, if any.
+    pub fn leader(&self) -> Option<&TeamMember> {
+        self.members.iter().find(|m| m.is_leader)
+    }
+}
+
+/// Events emitted when team state changes.
+#[derive(Debug, Clone)]
+pub enum TeamEvent {
+    /// A team was created or updated.
+    TeamUpdated { team_name: String, state: TeamState },
+    /// A team was removed (config deleted).
+    TeamRemoved { team_name: String },
+}

--- a/crates/kild-teams/src/watcher.rs
+++ b/crates/kild-teams/src/watcher.rs
@@ -1,0 +1,265 @@
+//! File watcher for team config and shim pane registry changes.
+//!
+//! Follows the `SessionWatcher` pattern from `kild-ui/src/watcher.rs`.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::Path;
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+
+/// Watches team-related directories for changes.
+///
+/// Monitors both `~/.claude/teams/` (team configs) and `~/.kild/shim/`
+/// (pane registries) for file system events.
+pub struct TeamWatcher {
+    /// Underlying notify watchers. Must be kept alive.
+    _watchers: Vec<RecommendedWatcher>,
+    /// Channel receiver for file events.
+    receiver: Receiver<Result<Event, notify::Error>>,
+}
+
+impl TeamWatcher {
+    /// Create a new team watcher.
+    ///
+    /// Watches `~/.claude/teams/` recursively (config.json is nested in subdirs)
+    /// and `~/.kild/shim/` recursively (pane registries are nested).
+    ///
+    /// Returns `None` if no directories can be watched.
+    pub fn new(teams_dir: Option<&Path>, shim_dir: Option<&Path>) -> Option<Self> {
+        let (tx, rx) = mpsc::channel();
+        let mut watchers = Vec::new();
+
+        if let Some(dir) = teams_dir
+            && dir.is_dir()
+        {
+            match Self::create_watcher(dir, RecursiveMode::Recursive, tx.clone()) {
+                Some(w) => {
+                    tracing::info!(
+                        event = "teams.watcher.watching_teams",
+                        path = %dir.display()
+                    );
+                    watchers.push(w);
+                }
+                None => {
+                    tracing::warn!(
+                        event = "teams.watcher.teams_watch_failed",
+                        path = %dir.display()
+                    );
+                }
+            }
+        }
+
+        if let Some(dir) = shim_dir
+            && dir.is_dir()
+        {
+            match Self::create_watcher(dir, RecursiveMode::Recursive, tx.clone()) {
+                Some(w) => {
+                    tracing::info!(
+                        event = "teams.watcher.watching_shim",
+                        path = %dir.display()
+                    );
+                    watchers.push(w);
+                }
+                None => {
+                    tracing::warn!(
+                        event = "teams.watcher.shim_watch_failed",
+                        path = %dir.display()
+                    );
+                }
+            }
+        }
+
+        if watchers.is_empty() {
+            tracing::debug!(
+                event = "teams.watcher.no_dirs_available",
+                "No directories available to watch"
+            );
+            return None;
+        }
+
+        Some(Self {
+            _watchers: watchers,
+            receiver: rx,
+        })
+    }
+
+    /// Create a watcher for default directories.
+    ///
+    /// Resolves `~/.claude/teams/` and `~/.kild/shim/` via `dirs::home_dir()`.
+    pub fn new_default() -> Option<Self> {
+        let home = dirs::home_dir()?;
+        let teams_dir = home.join(".claude").join("teams");
+        let shim_dir = home.join(".kild").join("shim");
+
+        Self::new(Some(&teams_dir), Some(&shim_dir))
+    }
+
+    /// Check for pending file events (non-blocking).
+    ///
+    /// Returns `true` if any relevant events (config.json or panes.json changes)
+    /// were detected since the last call. Drains all pending events.
+    pub fn has_pending_events(&self) -> bool {
+        let mut found_relevant = false;
+
+        loop {
+            match self.receiver.try_recv() {
+                Ok(Ok(event)) => {
+                    if Self::is_relevant_event(&event) && !found_relevant {
+                        tracing::debug!(
+                            event = "teams.watcher.event_detected",
+                            kind = ?event.kind,
+                            paths = ?event.paths
+                        );
+                        found_relevant = true;
+                    }
+                    // Continue draining
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(event = "teams.watcher.event_error", error = %e);
+                }
+                Err(TryRecvError::Empty) => return found_relevant,
+                Err(TryRecvError::Disconnected) => {
+                    tracing::warn!(event = "teams.watcher.channel_disconnected");
+                    return found_relevant;
+                }
+            }
+        }
+    }
+
+    fn create_watcher(
+        dir: &Path,
+        mode: RecursiveMode,
+        tx: mpsc::Sender<Result<Event, notify::Error>>,
+    ) -> Option<RecommendedWatcher> {
+        let mut watcher = notify::recommended_watcher(tx).ok()?;
+        watcher.watch(dir, mode).ok()?;
+        Some(watcher)
+    }
+
+    /// Check if an event is relevant (config.json or panes.json changes).
+    fn is_relevant_event(event: &Event) -> bool {
+        let is_relevant_kind = matches!(
+            event.kind,
+            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        );
+
+        if !is_relevant_kind {
+            return false;
+        }
+
+        event.paths.iter().any(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|name| name == "config.json" || name == "panes.json")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{CreateKind, ModifyKind, RemoveKind};
+    use std::path::PathBuf;
+
+    fn make_event(kind: EventKind, paths: Vec<PathBuf>) -> Event {
+        Event {
+            kind,
+            paths,
+            attrs: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_relevant_event_config_json() {
+        let event = make_event(
+            EventKind::Create(CreateKind::File),
+            vec![PathBuf::from("/teams/my-team/config.json")],
+        );
+        assert!(TeamWatcher::is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_relevant_event_panes_json() {
+        let event = make_event(
+            EventKind::Modify(ModifyKind::Data(notify::event::DataChange::Content)),
+            vec![PathBuf::from("/shim/session/panes.json")],
+        );
+        assert!(TeamWatcher::is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_ignores_other_json() {
+        let event = make_event(
+            EventKind::Create(CreateKind::File),
+            vec![PathBuf::from("/teams/my-team/inboxes/agent.json")],
+        );
+        assert!(!TeamWatcher::is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_ignores_non_json() {
+        let event = make_event(
+            EventKind::Create(CreateKind::File),
+            vec![PathBuf::from("/teams/my-team/something.txt")],
+        );
+        assert!(!TeamWatcher::is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_relevant_event_remove() {
+        let event = make_event(
+            EventKind::Remove(RemoveKind::File),
+            vec![PathBuf::from("/teams/old-team/config.json")],
+        );
+        assert!(TeamWatcher::is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_ignores_access_events() {
+        let event = make_event(
+            EventKind::Access(notify::event::AccessKind::Read),
+            vec![PathBuf::from("/teams/team/config.json")],
+        );
+        assert!(!TeamWatcher::is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_new_with_missing_dirs() {
+        // Both dirs don't exist — should return None
+        let watcher = TeamWatcher::new(
+            Some(Path::new("/nonexistent/teams")),
+            Some(Path::new("/nonexistent/shim")),
+        );
+        assert!(watcher.is_none());
+    }
+
+    #[test]
+    fn test_new_with_existing_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let watcher = TeamWatcher::new(Some(dir.path()), None);
+        assert!(watcher.is_some());
+    }
+
+    #[test]
+    fn test_has_pending_events_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let watcher = TeamWatcher::new(Some(dir.path()), None).unwrap();
+        assert!(!watcher.has_pending_events());
+    }
+
+    #[test]
+    fn test_has_pending_events_detects_config_change() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let team_dir = dir.path().join("my-team");
+        std::fs::create_dir_all(&team_dir).unwrap();
+
+        let watcher = TeamWatcher::new(Some(dir.path()), None).unwrap();
+
+        // Create config.json
+        std::fs::write(team_dir.join("config.json"), r#"{"members":[]}"#).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        assert!(watcher.has_pending_events());
+        // Drained
+        assert!(!watcher.has_pending_events());
+    }
+}

--- a/crates/kild-ui/Cargo.toml
+++ b/crates/kild-ui/Cargo.toml
@@ -30,6 +30,7 @@ vte.workspace = true
 futures.workspace = true
 smol.workspace = true
 kild-protocol.workspace = true
+kild-teams.workspace = true
 base64.workspace = true
 
 # core-text is macOS-only; pinned to fix gpui font-kit conflict

--- a/crates/kild-ui/src/main.rs
+++ b/crates/kild-ui/src/main.rs
@@ -13,6 +13,7 @@ mod components;
 mod daemon_client;
 mod refresh;
 mod state;
+mod teams;
 mod terminal;
 mod theme;
 mod theme_bridge;

--- a/crates/kild-ui/src/teams/mod.rs
+++ b/crates/kild-ui/src/teams/mod.rs
@@ -1,0 +1,28 @@
+//! Agent team integration for kild-ui.
+//!
+//! Feature boundary: all team-related code is isolated here.
+//! Removing this module requires only removing `mod teams;`,
+//! two MainView fields, and one `render_sidebar` parameter.
+
+mod state;
+
+pub use state::TeamManager;
+
+use crate::theme;
+use gpui::Rgba;
+use kild_teams::TeamColor;
+
+/// Map Claude Code team colors to the Tallinn Night palette.
+pub fn team_color_to_rgba(color: &TeamColor) -> Rgba {
+    match color {
+        TeamColor::Red => theme::ember(),
+        TeamColor::Blue => theme::ice(),
+        TeamColor::Green => theme::aurora(),
+        TeamColor::Yellow => gpui::rgb(0xE5C07B),
+        TeamColor::Purple => gpui::rgb(0xC678DD),
+        TeamColor::Orange => theme::copper(),
+        TeamColor::Pink => gpui::rgb(0xFF7EB6),
+        TeamColor::Cyan => gpui::rgb(0x56B6C2),
+        TeamColor::Unknown => theme::text_muted(),
+    }
+}

--- a/crates/kild-ui/src/teams/state.rs
+++ b/crates/kild-ui/src/teams/state.rs
@@ -1,0 +1,149 @@
+//! Team state manager for the UI.
+//!
+//! Owns the team watcher and cached team state. Provides queries
+//! for the sidebar and main view to discover teammates.
+
+use std::collections::HashMap;
+
+use kild_teams::{TeamMember, TeamState, TeamWatcher};
+
+/// Manages team state for the UI, providing cached team data
+/// and file-watching for live updates.
+pub struct TeamManager {
+    /// Cached team states keyed by kild session_id.
+    team_states: HashMap<String, TeamState>,
+    /// File watcher for team config and shim registry changes.
+    watcher: Option<TeamWatcher>,
+    /// Mapping from team_name → kild session_id (for cross-referencing).
+    team_to_session: HashMap<String, String>,
+}
+
+impl TeamManager {
+    pub fn new() -> Self {
+        let watcher = TeamWatcher::new_default();
+        if watcher.is_some() {
+            tracing::info!(event = "ui.teams.watcher_created");
+        } else {
+            tracing::debug!(event = "ui.teams.watcher_unavailable");
+        }
+
+        Self {
+            team_states: HashMap::new(),
+            watcher,
+            team_to_session: HashMap::new(),
+        }
+    }
+
+    /// Re-scan teams and cross-reference with shim registries.
+    ///
+    /// Called when the watcher detects changes or periodically.
+    /// Takes a set of known daemon kild session IDs and their branch names
+    /// to cross-reference teams with sessions.
+    pub fn refresh(&mut self, session_ids: &[(&str, &str)]) {
+        let teams = kild_teams::scanner::scan_teams_default();
+
+        self.team_states.clear();
+        self.team_to_session.clear();
+
+        for (team_name, team_state) in teams {
+            // Try to match this team to a kild session by scanning shim registries.
+            // For each known session, check if the shim has teammates.
+            let mut matched = false;
+
+            for &(session_id, _branch) in session_ids {
+                match kild_teams::mapper::resolve_team(team_state.clone(), session_id) {
+                    Ok(resolved) if resolved.kild_session_id.is_some() => {
+                        // Check if any member actually resolved a daemon_session_id
+                        let has_resolved_members = resolved
+                            .members
+                            .iter()
+                            .any(|m| m.daemon_session_id.is_some());
+                        if has_resolved_members {
+                            tracing::debug!(
+                                event = "ui.teams.team_matched",
+                                team = team_name,
+                                session_id = session_id,
+                                members = resolved.members.len()
+                            );
+                            self.team_to_session
+                                .insert(team_name.clone(), session_id.to_string());
+                            self.team_states.insert(session_id.to_string(), resolved);
+                            matched = true;
+                            break;
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            event = "ui.teams.resolve_failed",
+                            team = team_name,
+                            session_id = session_id,
+                            error = %e
+                        );
+                    }
+                }
+            }
+
+            if !matched {
+                tracing::debug!(
+                    event = "ui.teams.team_unmatched",
+                    team = team_name,
+                    "No kild session matched for team"
+                );
+            }
+        }
+
+        // Fallback: for sessions without a team config match, try shim discovery
+        for &(session_id, _branch) in session_ids {
+            if self.team_states.contains_key(session_id) {
+                continue;
+            }
+            match kild_teams::discovery::discover_teammates(session_id) {
+                Ok(Some(members)) => {
+                    tracing::debug!(
+                        event = "ui.teams.fallback_discovery",
+                        session_id = session_id,
+                        members = members.len()
+                    );
+                    self.team_states.insert(
+                        session_id.to_string(),
+                        TeamState {
+                            team_name: format!("shim-{}", session_id),
+                            kild_session_id: Some(session_id.to_string()),
+                            members,
+                        },
+                    );
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::debug!(
+                        event = "ui.teams.fallback_discovery_failed",
+                        session_id = session_id,
+                        error = %e
+                    );
+                }
+            }
+        }
+    }
+
+    /// Get team state for a kild session.
+    #[allow(dead_code)]
+    pub fn team_for_session(&self, session_id: &str) -> Option<&TeamState> {
+        self.team_states.get(session_id)
+    }
+
+    /// Get non-leader teammates for a kild session.
+    pub fn teammates_for_session(&self, session_id: &str) -> Vec<&TeamMember> {
+        self.team_states
+            .get(session_id)
+            .map(|t| t.teammates().collect())
+            .unwrap_or_default()
+    }
+
+    /// Check if the watcher has pending events.
+    pub fn has_pending_events(&self) -> bool {
+        self.watcher
+            .as_ref()
+            .is_some_and(|w| w.has_pending_events())
+    }
+}

--- a/crates/kild-ui/src/views/detail_view.rs
+++ b/crates/kild-ui/src/views/detail_view.rs
@@ -349,6 +349,7 @@ fn render_terminal_list(
         let mode = match entry.backend() {
             TerminalBackend::Daemon { .. } => "daemon",
             TerminalBackend::Local => "local",
+            TerminalBackend::Teammate { .. } => "team",
         };
         let sid = session_id.to_string();
         let tab_idx = i;

--- a/crates/kild-ui/src/views/sidebar.rs
+++ b/crates/kild-ui/src/views/sidebar.rs
@@ -353,13 +353,16 @@ fn render_terminal_item(
         .get(tab_idx)
         .map(|e| e.label().to_string())
         .unwrap_or_default();
-    let mode_label = tabs
+    let (mode_label, effective_dot_color) = tabs
         .get(tab_idx)
         .map(|e| match e.backend() {
-            crate::views::terminal_tabs::TerminalBackend::Local => "local",
-            crate::views::terminal_tabs::TerminalBackend::Daemon { .. } => "daemon",
+            crate::views::terminal_tabs::TerminalBackend::Local => ("local", dot_color),
+            crate::views::terminal_tabs::TerminalBackend::Daemon { .. } => ("daemon", dot_color),
+            crate::views::terminal_tabs::TerminalBackend::Teammate { color, .. } => {
+                ("team", crate::teams::team_color_to_rgba(color))
+            }
         })
-        .unwrap_or("local");
+        .unwrap_or(("local", dot_color));
     let in_grid = pane_grid.find_slot(session_id, tab_idx).is_some();
     let sid: gpui::SharedString = format!("sidebar-tab-{}-{}", session_id, tab_idx).into();
     let sid_close: gpui::SharedString =
@@ -387,13 +390,13 @@ fn render_terminal_item(
                 view.on_sidebar_terminal_click(&sid_for_click, tab_idx, window, cx);
             }),
         )
-        // Status dot
+        // Status dot (uses team color for teammate tabs)
         .child(
             div()
                 .size(px(theme::TERMINAL_DOT_SIZE))
                 .rounded_full()
                 .flex_shrink_0()
-                .bg(dot_color),
+                .bg(effective_dot_color),
         )
         // Terminal name
         .child(


### PR DESCRIPTION
## Summary

- Add `kild-teams` crate for discovering and tracking Claude Code agent teams (37 unit tests)
- Auto-surface teammate terminals in sidebar and pane grid when Claude Code spawns agent teams in daemon mode
- Add team member colors, dashboard badge, and Cmd+Shift+J/K keyboard navigation

## What it does

When Claude Code creates an agent team inside a daemon-managed kild session, the tmux shim creates separate daemon PTYs for each teammate. This PR makes those teammate terminals automatically visible in the kild UI:

1. **kild-teams crate** (Phase 1) — Standalone library that parses `~/.claude/teams/` config, cross-references with shim pane registry, and resolves teammate daemon session IDs. Fallback discovery from shim registry when no team config exists.

2. **UI integration** (Phase 2) — TeamManager polls for team changes at 200ms, auto-creates teammate terminal tabs via existing `connect_for_attach()` pipeline. Teammate tabs show "team" label and colored dots in sidebar.

3. **Rich experience** (Phase 3, partial) — Team member colors mapped to Tallinn Night palette, "{N} agents" badge on dashboard cards, Cmd+Shift+J/K cycles between terminal tabs.

## Known gaps (future work)

- Teammate leave tab cleanup (tabs persist until manual close)
- Team status tracking (working/idle/waiting badges)
- Auto-layout in pane grid when team forms
- Team-level actions (stop all teammates)
- Activity indicators (unread output dots)

## Test plan

- [x] `cargo fmt --check && cargo clippy --all -- -D warnings && cargo test --all`
- [x] Manual: create daemon kild, run Claude Code with agent teams, verify teammate terminals appear in sidebar
- [x] Manual: verify teammate terminals render live output in pane grid
- [x] Manual: verify Cmd+Shift+J/K cycles between tabs
- [x] Manual: verify dashboard shows agent count badge