### PR TITLE
test: add comprehensive session lifecycle unit tests (#423)

### DIFF
--- a/crates/kild-core/src/sessions/agent_status.rs
+++ b/crates/kild-core/src/sessions/agent_status.rs
@@ -99,7 +99,6 @@ pub fn find_session_by_worktree_path(
 mod tests {
     use super::*;
 
-    /// Test worktree path matching logic: exact path match.
     #[test]
     fn test_worktree_path_match_exact() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -109,27 +108,10 @@ mod tests {
         let worktree = tmp.path().join("worktree");
         std::fs::create_dir_all(&worktree).unwrap();
 
-        let session = Session::new(
-            "test/feat".to_string(),
-            "test".to_string(),
-            "feat".to_string(),
-            worktree.clone(),
-            "claude".to_string(),
-            super::super::types::SessionStatus::Active,
-            "2024-01-01T00:00:00Z".to_string(),
-            0,
-            0,
-            0,
-            None,
-            None,
-            vec![],
-            None,
-            None,
-            None,
-        );
+        let mut session = Session::new_for_test("feat".to_string(), worktree.clone());
+        session.worktree_path = worktree.clone();
         persistence::save_session_to_file(&session, &sessions_dir).unwrap();
 
-        // Load sessions and replicate the path matching logic
         let (sessions, _) = persistence::load_sessions_from_files(&sessions_dir).unwrap();
         let found = sessions
             .iter()
@@ -138,7 +120,6 @@ mod tests {
         assert_eq!(found.unwrap().branch, "feat");
     }
 
-    /// Test worktree path matching logic: subdirectory matches.
     #[test]
     fn test_worktree_path_match_subdirectory() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -148,29 +129,12 @@ mod tests {
         let worktree = tmp.path().join("worktree");
         std::fs::create_dir_all(&worktree).unwrap();
 
-        let session = Session::new(
-            "test/feat".to_string(),
-            "test".to_string(),
-            "feat".to_string(),
-            worktree.clone(),
-            "claude".to_string(),
-            super::super::types::SessionStatus::Active,
-            "2024-01-01T00:00:00Z".to_string(),
-            0,
-            0,
-            0,
-            None,
-            None,
-            vec![],
-            None,
-            None,
-            None,
-        );
+        let mut session = Session::new_for_test("feat".to_string(), worktree.clone());
+        session.worktree_path = worktree.clone();
         persistence::save_session_to_file(&session, &sessions_dir).unwrap();
 
         let (sessions, _) = persistence::load_sessions_from_files(&sessions_dir).unwrap();
 
-        // Subdirectory of worktree should match
         let subdir = worktree.join("src").join("main.rs");
         let found = sessions
             .iter()
@@ -179,7 +143,6 @@ mod tests {
         assert_eq!(found.unwrap().branch, "feat");
     }
 
-    /// Test worktree path matching logic: non-matching path returns None.
     #[test]
     fn test_worktree_path_no_match() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -189,29 +152,12 @@ mod tests {
         let worktree = tmp.path().join("worktree");
         std::fs::create_dir_all(&worktree).unwrap();
 
-        let session = Session::new(
-            "test/feat".to_string(),
-            "test".to_string(),
-            "feat".to_string(),
-            worktree,
-            "claude".to_string(),
-            super::super::types::SessionStatus::Active,
-            "2024-01-01T00:00:00Z".to_string(),
-            0,
-            0,
-            0,
-            None,
-            None,
-            vec![],
-            None,
-            None,
-            None,
-        );
+        let mut session = Session::new_for_test("feat".to_string(), worktree.clone());
+        session.worktree_path = worktree;
         persistence::save_session_to_file(&session, &sessions_dir).unwrap();
 
         let (sessions, _) = persistence::load_sessions_from_files(&sessions_dir).unwrap();
 
-        // Completely different path should not match
         let other_path = tmp.path().join("other_project");
         let found = sessions
             .iter()

--- a/crates/kild-core/src/sessions/errors.rs
+++ b/crates/kild-core/src/sessions/errors.rs
@@ -279,8 +279,6 @@ mod tests {
         assert!(!error.is_user_error());
     }
 
-    // --- Exhaustive error_code and is_user_error tests for all remaining variants ---
-
     #[test]
     fn test_worktree_not_found_error() {
         let error = SessionError::WorktreeNotFound {
@@ -416,15 +414,12 @@ mod tests {
 
     #[test]
     fn test_daemon_auto_start_failed_delegates_is_user_error() {
-        // DaemonAutoStartFailed delegates is_user_error to the nested source.
-        // Disabled is a user error:
         let disabled_error = SessionError::DaemonAutoStartFailed {
             source: crate::daemon::errors::DaemonAutoStartError::Disabled,
         };
         assert_eq!(disabled_error.error_code(), "DAEMON_AUTO_START_FAILED");
         assert!(disabled_error.is_user_error());
 
-        // SpawnFailed is NOT a user error:
         let spawn_error = SessionError::DaemonAutoStartFailed {
             source: crate::daemon::errors::DaemonAutoStartError::SpawnFailed {
                 message: "failed".to_string(),

--- a/crates/kild-core/src/sessions/persistence.rs
+++ b/crates/kild-core/src/sessions/persistence.rs
@@ -1354,8 +1354,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
-    /// Test that save→load round-trip preserves ALL fields including newer ones
-    /// (agent_session_id, task_list_id, runtime_mode, agents with full metadata).
     #[test]
     fn test_save_load_roundtrip_all_fields() {
         use crate::state::types::RuntimeMode;
@@ -1364,7 +1362,6 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let sessions_dir = tmp.path();
 
-        // Create worktree directory so validation passes
         let worktree_dir = sessions_dir.join("worktree");
         std::fs::create_dir_all(&worktree_dir).unwrap();
 
@@ -1436,7 +1433,6 @@ mod tests {
         assert!(agent.daemon_session_id().is_none());
     }
 
-    /// Test that the session ID `/` to `_` filename mapping is correct.
     #[test]
     fn test_session_id_filename_mapping() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -1466,11 +1462,9 @@ mod tests {
 
         save_session_to_file(&session, sessions_dir).unwrap();
 
-        // The file should use underscores for slashes
         let expected_file = sessions_dir.join("my-project_deep_nested.json");
-        assert!(expected_file.exists(), "Session file should use _ for /");
+        assert!(expected_file.exists());
 
-        // Load back and verify
         let loaded = load_session_from_file("deep-nested", sessions_dir).unwrap();
         assert_eq!(loaded.id, "my-project/deep/nested");
     }

--- a/crates/kild-core/src/sessions/ports.rs
+++ b/crates/kild-core/src/sessions/ports.rs
@@ -250,8 +250,6 @@ mod tests {
         assert!(names.contains(&"KILD_PORT_COUNT"));
     }
 
-    // --- allocate_port_range integration tests (filesystem-based) ---
-
     #[test]
     fn test_allocate_port_range_empty_dir() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -264,32 +262,14 @@ mod tests {
     fn test_allocate_port_range_avoids_existing_session() {
         let tmp = tempfile::TempDir::new().unwrap();
 
-        // Create worktree directory for structural validation
         let wt = tmp.path().join("wt");
         std::fs::create_dir_all(&wt).unwrap();
 
-        // Write a session file with ports 3000-3009
-        let existing = create_session_with_ports(3000, 3009);
-        // Need a session with a valid worktree for load validation
-        let existing_with_wt = Session::new(
-            existing.id.clone(),
-            existing.project_id.clone(),
-            existing.branch.clone(),
-            wt,
-            existing.agent.clone(),
-            existing.status.clone(),
-            existing.created_at.clone(),
-            existing.port_range_start,
-            existing.port_range_end,
-            existing.port_count,
-            None,
-            None,
-            vec![],
-            None,
-            None,
-            None,
-        );
-        super::super::persistence::save_session_to_file(&existing_with_wt, tmp.path()).unwrap();
+        let mut existing = Session::new_for_test("existing".to_string(), wt);
+        existing.port_range_start = 3000;
+        existing.port_range_end = 3009;
+        existing.port_count = 10;
+        super::super::persistence::save_session_to_file(&existing, tmp.path()).unwrap();
 
         let (start, end) = allocate_port_range(tmp.path(), 10, 3000).unwrap();
         assert_eq!(start, 3010);
@@ -301,7 +281,6 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let nonexistent = tmp.path().join("does_not_exist");
 
-        // Non-existent dir returns empty sessions, so first range
         let (start, end) = allocate_port_range(&nonexistent, 10, 3000).unwrap();
         assert_eq!(start, 3000);
         assert_eq!(end, 3009);

--- a/crates/kild-core/src/sessions/types.rs
+++ b/crates/kild-core/src/sessions/types.rs
@@ -1777,8 +1777,6 @@ mod tests {
         }
     }
 
-    // --- Session/AgentProcess construction invariant tests ---
-
     #[test]
     fn test_session_new_sets_all_fields() {
         use crate::state::types::RuntimeMode;
@@ -1854,7 +1852,6 @@ mod tests {
 
     #[test]
     fn test_agent_process_daemon_only_no_pid() {
-        // Daemon-managed agent: no PID, has daemon_session_id
         let agent = AgentProcess::new(
             "claude".to_string(),
             "proj_feat_0".to_string(),


### PR DESCRIPTION
## Summary

- Add 42 new unit tests across 7 files in `kild-core/src/sessions/` and `kild-core/src/state/`
- Cover error type exhaustiveness (all 25 `SessionError` variants now tested for `error_code()` and `is_user_error()`)
- Add persistence save→load full-field round-trip, agent status worktree path-matching, filesystem-based port allocation, DestroySafetyInfo behavior, Session/AgentProcess type invariants, and CoreStore dispatch error paths for all session commands
- Total kild-core test count: 898 passing

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes (0 warnings)
- [x] `cargo test -p kild-core` passes (898 tests)
- [x] `cargo test --all` passes
- [x] `cargo build --all` succeeds