### PR TITLE
feat(ui): add minimize button to sidebar terminal items

### DIFF
--- a/crates/kild-ui/src/views/main_view.rs
+++ b/crates/kild-ui/src/views/main_view.rs
@@ -1801,6 +1801,36 @@ impl MainView {
         cx.notify();
     }
 
+    /// Remove terminal from pane grid without killing it.
+    pub(crate) fn on_minimize_tab(
+        &mut self,
+        session_id: &str,
+        tab_idx: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(slot_idx) = self.pane_grid.find_slot(session_id, tab_idx) {
+            self.pane_grid.remove(slot_idx);
+
+            if let Some(next) = self.pane_grid.next_occupied_slot() {
+                self.pane_grid.set_focus(next);
+                if let super::pane_grid::PaneSlot::Occupied {
+                    session_id: next_sid,
+                    ..
+                } = self.pane_grid.slot(next)
+                {
+                    self.active_terminal_id = Some(next_sid.clone());
+                }
+            } else {
+                self.active_terminal_id = None;
+                self.active_view = ActiveView::Dashboard;
+                self.focus_region = FocusRegion::Dashboard;
+                window.focus(&self.focus_handle);
+            }
+            cx.notify();
+        }
+    }
+
     #[allow(dead_code)]
     pub(crate) fn on_close_tab(
         &mut self,

--- a/crates/kild-ui/src/views/sidebar.rs
+++ b/crates/kild-ui/src/views/sidebar.rs
@@ -367,8 +367,11 @@ fn render_terminal_item(
     let sid: gpui::SharedString = format!("sidebar-tab-{}-{}", session_id, tab_idx).into();
     let sid_close: gpui::SharedString =
         format!("sidebar-tab-close-{}-{}", session_id, tab_idx).into();
+    let sid_minimize: gpui::SharedString =
+        format!("sidebar-tab-min-{}-{}", session_id, tab_idx).into();
     let sid_for_click = session_id.to_string();
     let sid_for_close = session_id.to_string();
+    let sid_for_minimize = session_id.to_string();
 
     div()
         .id(sid)
@@ -422,7 +425,7 @@ fn render_terminal_item(
                 .group_hover("terminal-row", |s| s.opacity(0.0))
                 .child(mode_label),
         )
-        // Hover action: × (close/destroy terminal)
+        // Hover actions: − (minimize) and × (close)
         .child(
             div()
                 .absolute()
@@ -431,9 +434,31 @@ fn render_terminal_item(
                 .bottom_0()
                 .flex()
                 .items_center()
+                .gap(px(1.0))
                 .bg(theme::surface())
                 .opacity(0.0)
                 .group_hover("terminal-row", |s| s.opacity(1.0))
+                // − (minimize): remove from pane grid, keep alive
+                .when(in_grid, |this| {
+                    this.child(
+                        div()
+                            .id(sid_minimize)
+                            .px(px(3.0))
+                            .cursor_pointer()
+                            .text_size(px(theme::TEXT_XXS))
+                            .text_color(theme::text_muted())
+                            .rounded(px(theme::SPACE_HALF))
+                            .hover(|s| s.text_color(theme::text()).bg(theme::elevated()))
+                            .on_mouse_up(
+                                gpui::MouseButton::Left,
+                                cx.listener(move |view, _, window, cx| {
+                                    view.on_minimize_tab(&sid_for_minimize, tab_idx, window, cx);
+                                }),
+                            )
+                            .child("\u{2212}"), // −
+                    )
+                })
+                // × (close): destroy terminal entirely
                 .child(
                     div()
                         .id(sid_close)


### PR DESCRIPTION
## Summary

- Add hover-revealed minimize (−) button to sidebar terminal items, completing #440
- The − button removes a terminal from the pane grid without killing it (keep alive)
- Only appears when the terminal is currently displayed in the grid
- Existing × (close) button behavior unchanged

## Test plan

- [ ] Hover over a terminal item in the sidebar — both − and × buttons appear
- [ ] − button only visible when terminal is in the pane grid
- [ ] Click − — terminal removed from grid, still listed in sidebar
- [ ] Click × — terminal destroyed entirely (unchanged behavior)

Closes #440