### PR TITLE
feat: auto-open Ghostty attach window for CLI daemon sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -575,7 +575,7 @@ Runtime mode resolution for `kild create`:
 3. Config `daemon.enabled = true` → Daemon mode
 4. Default → Terminal mode
 
-All sessions store their `runtime_mode` (Terminal or Daemon) in the session file. Sessions created with `--daemon` also store `daemon_session_id` in `AgentProcess`. Daemon sessions automatically open a Ghostty attach window running `kild attach <branch>` for immediate visual feedback (Ctrl+C to detach). If auto-attach fails, manually run `kild attach <branch>`.
+All sessions store their `runtime_mode` (Terminal or Daemon) in the session file. Sessions created with `--daemon` also store `daemon_session_id` in `AgentProcess`. Daemon sessions automatically open a terminal attach window running `kild attach <branch>` for immediate visual feedback (Ctrl+C to detach). If auto-attach fails, manually run `kild attach <branch>`.
 
 Runtime mode resolution for `kild open`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,7 +565,7 @@ Runtime mode resolution for `kild create`:
 3. Config `daemon.enabled = true` → Daemon mode
 4. Default → Terminal mode
 
-All sessions store their `runtime_mode` (Terminal or Daemon) in the session file. Sessions created with `--daemon` also store `daemon_session_id` in `AgentProcess`. Daemon sessions automatically open a Ghostty attach window running `kild attach <branch>` for immediate visual feedback (Ctrl+C to detach). If auto-attach fails, manually run `kild attach <branch>`.
+All sessions store their `runtime_mode` (Terminal or Daemon) in the session file. Sessions created with `--daemon` also store `daemon_session_id` in `AgentProcess`. Daemon sessions automatically open a terminal attach window running `kild attach <branch>` for immediate visual feedback (Ctrl+C to detach). If auto-attach fails, manually run `kild attach <branch>`.
 
 Runtime mode resolution for `kild open`:
 1. `--daemon` flag → Daemon mode

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ kild attach <branch>
 # Press Ctrl+C to detach
 ```
 
-**Note**: Daemon mode is experimental (Phase 1b). The daemon runtime supports background and foreground modes, auto-start via config, scrollback replay on attach, PTY exit notification with automatic session state updates, and works with both `kild create` and `kild open` commands. When creating or opening daemon sessions, KILD automatically spawns a Ghostty attach window for immediate visual feedback. Daemon sessions automatically enable Claude Code agent teams by injecting a tmux-compatible shim.
+**Note**: Daemon mode is experimental (Phase 1b). The daemon runtime supports background and foreground modes, auto-start via config, scrollback replay on attach, PTY exit notification with automatic session state updates, and works with both `kild create` and `kild open` commands. When creating or opening daemon sessions, KILD automatically spawns a terminal attach window for immediate visual feedback. Daemon sessions automatically enable Claude Code agent teams by injecting a tmux-compatible shim.
 
 ### Stop a kild
 ```bash

--- a/crates/kild/src/commands/create.rs
+++ b/crates/kild/src/commands/create.rs
@@ -62,7 +62,7 @@ pub(crate) fn handle_create_command(
 
     match session_ops::create_session(request, &config) {
         Ok(session) => {
-            // Auto-attach: open a Ghostty window for daemon sessions
+            // Auto-attach: open a terminal window for daemon sessions
             if session.runtime_mode == Some(kild_core::RuntimeMode::Daemon) {
                 let spawn_id = session
                     .latest_agent()

--- a/crates/kild/src/commands/open.rs
+++ b/crates/kild/src/commands/open.rs
@@ -32,7 +32,7 @@ pub(crate) fn handle_open_command(matches: &ArgMatches) -> Result<(), Box<dyn st
 
     match session_ops::open_session(branch, mode.clone(), runtime_mode, resume) {
         Ok(session) => {
-            // Auto-attach: open a Ghostty window for daemon sessions
+            // Auto-attach: open a terminal window for daemon sessions
             if session.runtime_mode == Some(kild_core::RuntimeMode::Daemon) {
                 let config = load_config_with_warning();
                 let spawn_id = session
@@ -111,7 +111,7 @@ fn handle_open_all(
         match session_ops::open_session(&session.branch, mode.clone(), runtime_mode.clone(), resume)
         {
             Ok(s) => {
-                // Auto-attach: open a Ghostty window for daemon sessions
+                // Auto-attach: open a terminal window for daemon sessions
                 if s.runtime_mode == Some(kild_core::RuntimeMode::Daemon) {
                     let spawn_id = s
                         .latest_agent()


### PR DESCRIPTION
## Summary

When daemon sessions are created or opened from the CLI, automatically spawn a Ghostty terminal window running `kild attach <branch>`. This gives CLI users immediate visual feedback while the daemon still owns the PTY — enabling UI access, agent teams, and scrollback persistence.

Previously, `kild create --daemon` created an invisible PTY session requiring a manual `kild attach` to interact. Now the attach window opens automatically.

## Changes

- Add `spawn_attach_window()` best-effort helper in `daemon_helpers.rs` — resolves the kild binary path via `current_exe()`, spawns Ghostty with the attach command, and returns terminal info on success
- Add `auto_attach: bool` to `CreateSessionRequest` — `true` for CLI (`new()`), `false` for UI (`with_project_path()`)
- Add `auto_attach: bool` parameter to `open_session()` — CLI passes `true`, UI dispatch passes `false`
- Wire auto-attach into daemon mode paths in `create.rs` and `open.rs` — calls `spawn_attach_window()` after daemon PTY creation, stores `terminal_window_id` and `terminal_type` on the `AgentProcess` for focus/hide/close operations
- Add `set_terminal_info()` setter on `AgentProcess` for post-construction terminal metadata updates

## Files Changed

6 files changed (+136/-12)

<details>
<summary>File list</summary>

- `crates/kild-core/src/sessions/daemon_helpers.rs` — new `spawn_attach_window()` helper (+67)
- `crates/kild-core/src/sessions/types.rs` — `auto_attach` field, `set_terminal_info()` method (+22/-1)
- `crates/kild-core/src/sessions/create.rs` — auto-attach wired into daemon path (+17/-2)
- `crates/kild-core/src/sessions/open.rs` — auto-attach wired into daemon path (+28/-2)
- `crates/kild-core/src/state/dispatch.rs` — UI passes `auto_attach: false` (+3/-1)
- `crates/kild/src/commands/open.rs` — CLI passes `auto_attach: true` (+11/-2)

</details>

## Design Decisions

- **Best-effort pattern**: If Ghostty is unavailable or spawn fails, warn and continue — the daemon session still works, user can manually `kild attach`
- **No PID tracking for attach window**: The attach process is ephemeral (Ctrl+C to detach), so no PID file is created
- **`auto_attach` parameter vs heuristic**: Explicit bool distinguishes CLI vs UI callers rather than inferring from `project_path.is_some()`

## Testing

- [x] `cargo fmt --check` — 0 issues
- [x] `cargo clippy --all -- -D warnings` — 0 warnings
- [x] `cargo test --all` — all pass
- [x] `cargo build --all` — clean build
- [ ] Manual: `kild create test --daemon` opens Ghostty window
- [ ] Manual: Ctrl+C in Ghostty detaches without killing agent
- [ ] Manual: `kild open test` (daemon session) opens Ghostty window

## Related Issues

Closes #452