### PR TITLE
fix(ui): skip daemon attach for stopped sessions

### DIFF
--- a/crates/kild-ui/src/views/main_view.rs
+++ b/crates/kild-ui/src/views/main_view.rs
@@ -1047,6 +1047,7 @@ impl MainView {
         else {
             return;
         };
+        let is_running = display.process_status == kild_core::ProcessStatus::Running;
         let daemon_session_id = display
             .session
             .agents()
@@ -1057,7 +1058,7 @@ impl MainView {
 
         self.show_add_menu = false;
 
-        if let Some(dsid) = daemon_session_id {
+        if is_running && let Some(dsid) = daemon_session_id {
             self.add_daemon_terminal_tab(session_id, &dsid, cx);
         } else {
             // No existing daemon session — create one on the fly
@@ -1279,7 +1280,8 @@ impl MainView {
             if matches!(
                 runtime_mode,
                 Some(kild_core::state::types::RuntimeMode::Daemon)
-            ) && let Some(ref dsid) = daemon_session_id
+            ) && display.process_status == kild_core::ProcessStatus::Running
+                && let Some(ref dsid) = daemon_session_id
             {
                 self.active_terminal_id = Some(id.clone());
                 self.focus_region = FocusRegion::Terminal;


### PR DESCRIPTION
## Summary

- Guard daemon attach calls with `process_status == Running` check in both `on_kild_select` and `on_add_daemon_tab`
- Stopped daemon sessions now fall through to the create-on-the-fly path instead of repeatedly erroring with `session_not_running`

Fixes the repeated `ui.terminal.daemon_attach_failed` errors when selecting stopped kilds in the sidebar.

## Test plan

- [x] `cargo fmt --check` — no violations
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --all` — all tests pass
- [ ] Start a daemon kild, stop it, click it in the UI sidebar — should not produce `daemon_attach_failed` errors
- [ ] Start a daemon kild, click it while running — should still attach normally