### PR TITLE
perf: replace Mutex with RwLock for scrollback, Vec<u8> with Bytes in broadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,6 +3439,7 @@ name = "kild-daemon"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "bytes",
  "chrono",
  "kild-core",
  "kild-paths",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ xcap = "0.8"
 image = "0.25"
 image-compare = "0.5"
 base64 = "0.22"
+bytes = "1"
 core-graphics = { version = "0.24", features = ["highsierra"] }
 core-foundation = "0.10"
 accessibility-sys = "0.2"

--- a/crates/kild-daemon/Cargo.toml
+++ b/crates/kild-daemon/Cargo.toml
@@ -36,6 +36,9 @@ thiserror.workspace = true
 # Binary encoding for PTY data
 base64.workspace = true
 
+# Zero-copy byte buffer for broadcast channel
+bytes.workspace = true
+
 # TOML config parsing
 toml.workspace = true
 

--- a/crates/kild-daemon/src/server/connection.rs
+++ b/crates/kild-daemon/src/server/connection.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use base64::Engine;
+use bytes::Bytes;
 use tokio::io::BufReader;
 use tokio::net::UnixStream;
 use tokio::sync::Mutex;
@@ -418,7 +419,7 @@ async fn dispatch_message(
 
 /// Stream PTY output to a client until detach, shutdown, or channel close.
 async fn stream_pty_output(
-    mut rx: tokio::sync::broadcast::Receiver<Vec<u8>>,
+    mut rx: tokio::sync::broadcast::Receiver<Bytes>,
     session_id: &str,
     writer: Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
     shutdown: tokio_util::sync::CancellationToken,

--- a/crates/kild-daemon/src/session/manager.rs
+++ b/crates/kild-daemon/src/session/manager.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bytes::Bytes;
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
@@ -139,7 +140,7 @@ impl SessionManager {
         &mut self,
         session_id: &str,
         client_id: ClientId,
-    ) -> Result<broadcast::Receiver<Vec<u8>>, DaemonError> {
+    ) -> Result<broadcast::Receiver<Bytes>, DaemonError> {
         let session = self
             .sessions
             .get_mut(session_id)
@@ -349,7 +350,7 @@ impl SessionManager {
     /// Handle a PTY exit event: transition the session to Stopped and clean up PTY.
     /// Returns the session_id and output_tx if the session had attached clients
     /// (so the caller can broadcast a session_event notification).
-    pub fn handle_pty_exit(&mut self, session_id: &str) -> Option<broadcast::Sender<Vec<u8>>> {
+    pub fn handle_pty_exit(&mut self, session_id: &str) -> Option<broadcast::Sender<Bytes>> {
         // Clean up PTY resources and capture exit code
         let exit_code = match self.pty_manager.remove(session_id) {
             Some(mut pty) => {


### PR DESCRIPTION
## Summary

Fixes the two remaining performance issues from #473:

1. **RwLock for scrollback**: Replace `Arc<Mutex<ScrollbackBuffer>>` with `Arc<RwLock<ScrollbackBuffer>>`. The PTY reader takes a write lock only for the brief `push()` call; clients attaching take a read lock that runs concurrently with reads from other attaching clients and does not block the PTY reader.

2. **`bytes::Bytes` in broadcast**: Change the broadcast channel element type from `Vec<u8>` to `bytes::Bytes`. Each 4KB PTY read now produces one heap allocation (backed by a single `Arc`) shared across all attached clients via refcount increment, instead of cloning bytes per receiver.

## Before / After

**Before:**
```
PTY read → to_vec() → Mutex.lock() → push() → broadcast::send(Vec<u8>)
                                                  └─ recv() → Vec<u8>::clone() per subscriber
Attach → Mutex.lock() ← BLOCKS PTY reader until contents() returns
```

**After:**
```
PTY read → Bytes::copy_from_slice() → RwLock.write() → push() → broadcast::send(Bytes)
                                                                    └─ recv() → Arc refcount per subscriber
Attach → RwLock.read() ← does NOT block PTY write lock
```

## Changes

- `Cargo.toml`: add `bytes = "1"` to workspace dependencies
- `crates/kild-daemon/Cargo.toml`: add `bytes.workspace = true`
- `crates/kild-daemon/src/pty/output.rs`: `Mutex` → `RwLock`, `Vec<u8>` → `Bytes`, update test assertions
- `crates/kild-daemon/src/session/state.rs`: `Mutex` → `RwLock`, `Vec<u8>` → `Bytes` in all field types and method signatures
- `crates/kild-daemon/src/server/connection.rs`: `Receiver<Vec<u8>>` → `Receiver<Bytes>`
- `crates/kild-daemon/src/session/manager.rs`: propagate `Bytes` through `attach_client` and `handle_pty_exit` return types

## Testing

- `cargo fmt --check` — pass
- `cargo clippy -p kild-daemon -- -D warnings` — 0 warnings
- `cargo test -p kild-daemon` — 87 unit tests + 14 integration tests pass
- `cargo test --all` — all crates pass
- `cargo build --all` — clean build

Closes #473