### PR TITLE
fix: address review findings from #504 perf PR

### DIFF
--- a/crates/kild-daemon/src/pty/mod.rs
+++ b/crates/kild-daemon/src/pty/mod.rs
@@ -2,4 +2,4 @@ pub mod manager;
 pub mod output;
 
 pub use manager::{ManagedPty, PtyManager};
-pub use output::{PtyExitEvent, PtyOutputBroadcaster, ScrollbackBuffer};
+pub use output::{PtyExitEvent, ScrollbackBuffer};

--- a/crates/kild-daemon/src/server/connection.rs
+++ b/crates/kild-daemon/src/server/connection.rs
@@ -472,6 +472,10 @@ async fn stream_pty_output(
                 }
             }
             _ = shutdown.cancelled() => {
+                debug!(
+                    event = "daemon.connection.stream_shutdown",
+                    session_id = session_id,
+                );
                 break;
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to #504 (RwLock/Bytes perf PR). Addresses findings from post-merge review:

- Add `error = %poisoned` and human-readable message to `scrollback_contents` read-lock poison handler — was inconsistent with the write-lock handler in `output.rs`
- Remove `PtyOutputBroadcaster` (dead production code — `create_session` bypasses it via `broadcast::channel` + `shared_scrollback` directly)
- Remove `data` intermediary in `spawn_pty_reader` — scrollback takes `&buf[..n]` directly, `Bytes::copy_from_slice` only at the send site
- Flatten `handle_pty_exit` tail with `?` instead of nested `if let Some(session)`
- Add context to `stop_transition_failed` log noting attached clients won't receive stopped notification
- Add `debug` log to `stream_pty_output` shutdown arm so shutdown vs PTY exit are distinguishable in logs