### PR TITLE
docs(state): fix Store trait doc — CLI never implements Store

### DIFF
--- a/crates/kild-core/src/state/store.rs
+++ b/crates/kild-core/src/state/store.rs
@@ -1,11 +1,9 @@
 use super::events::Event;
 use super::types::Command;
 
-/// Trait for dispatching business commands.
-///
-/// Decouples command definitions from their execution. Interfaces (CLI, UI)
-/// implement this trait to execute commands with their specific needs
-/// (e.g., UI adds event emission and async handling, CLI runs synchronously).
+/// Dispatch contract between command definitions and their execution.
+/// `CoreStore` is the production implementor. CLI calls handlers directly
+/// and does not implement this trait. Implemented by mocks in tests.
 ///
 /// # Semantics
 ///


### PR DESCRIPTION
## Summary

- Corrects the `Store` trait doc comment which incorrectly stated that CLI and UI implement this trait
- `CoreStore` is the only production implementor; CLI calls handlers directly; only mocks in tests implement it

Fixes #524