### PR TITLE
Refactor: explicitly pass KildConfig instead of using thread_local REMOTE_OVERRIDE

### DIFF
--- a/crates/kild-core/src/daemon/mod.rs
+++ b/crates/kild-core/src/daemon/mod.rs
@@ -61,25 +61,4 @@ pub fn find_sibling_binary(binary_name: &str) -> Result<PathBuf, String> {
     Ok(sibling)
 }
 
-// TODO: replace with explicit context parameter threaded through command handlers.
-// Thread-local override lets `--remote` CLI flag take precedence over config
-// without touching every command handler signature. Acceptable for the CLI
-// (single-threaded, one invocation = one call path).
-thread_local! {
-    static REMOTE_OVERRIDE: RefCell<Option<(String, Option<String>)>> = const { RefCell::new(None) };
-}
 
-/// Set a process-wide remote daemon override from CLI flags.
-///
-/// When set, `get_connection()` in `client.rs` connects via TCP/TLS
-/// regardless of the config file. Takes precedence over `remote_host` in config.
-pub fn set_remote_override(host: &str, fingerprint: Option<&str>) {
-    REMOTE_OVERRIDE.with(|cell| {
-        *cell.borrow_mut() = Some((host.to_string(), fingerprint.map(|s| s.to_string())));
-    });
-}
-
-/// Read the current remote override, if any.
-pub(crate) fn remote_override() -> Option<(String, Option<String>)> {
-    REMOTE_OVERRIDE.with(|cell| cell.borrow().clone())
-}

--- a/crates/kild-core/src/sessions/destroy.rs
+++ b/crates/kild-core/src/sessions/destroy.rs
@@ -123,14 +123,12 @@ pub fn cleanup_task_list(session_id: &str, task_list_id: &str, home_dir: &std::p
 /// When `force` is true:
 /// - Process kill failures are logged but don't block destruction
 /// - Worktree is force-deleted even with uncommitted changes (work will be lost)
-pub fn destroy_session(name: &str, force: bool) -> Result<(), SessionError> {
+pub fn destroy_session(name: &str, force: bool, config: &kild_config::KildConfig) -> Result<(), SessionError> {
     info!(
         event = "core.session.destroy_started",
         name = name,
         force = force
     );
-
-    let config = Config::new();
 
     // 1. Find session by name (branch name)
     let session =
@@ -170,7 +168,7 @@ pub fn destroy_session(name: &str, force: bool) -> Result<(), SessionError> {
                     daemon_session_id = daemon_sid,
                     agent = agent_proc.agent()
                 );
-                if let Err(e) = crate::daemon::client::destroy_daemon_session(daemon_sid, force) {
+                if let Err(e) = crate::daemon::client::destroy_daemon_session(daemon_sid, force, config) {
                     warn!(
                         event = "core.session.destroy_daemon_failed_continue",
                         daemon_session_id = daemon_sid,
@@ -309,7 +307,7 @@ pub fn destroy_session(name: &str, force: bool) -> Result<(), SessionError> {
                         daemon_session_id = %daemon_session.id,
                     );
                     if let Err(e) =
-                        crate::daemon::client::destroy_daemon_session(&daemon_session.id, true)
+                        crate::daemon::client::destroy_daemon_session(&daemon_session.id, true, config)
                     {
                         warn!(
                             event = "core.session.destroy_ui_session_failed",
@@ -365,7 +363,7 @@ pub fn destroy_session(name: &str, force: bool) -> Result<(), SessionError> {
                                         daemon_session_id = child_sid
                                     );
                                     if let Err(e) = crate::daemon::client::destroy_daemon_session(
-                                        child_sid, true,
+                                        child_sid, true, config
                                     ) {
                                         error!(
                                             event = "core.session.destroy_shim_child_failed",

--- a/crates/kild-core/src/sessions/open.rs
+++ b/crates/kild-core/src/sessions/open.rs
@@ -351,7 +351,7 @@ pub fn open_session(
 
         if let Some(exit_code) = maybe_early_exit {
             let scrollback_tail =
-                match crate::daemon::client::read_scrollback(&daemon_result.daemon_session_id) {
+                match crate::daemon::client::read_scrollback(&daemon_result.daemon_session_id, kild_config) {
                     Ok(Some(bytes)) => {
                         let text = String::from_utf8_lossy(&bytes);
                         let lines: Vec<&str> = text.lines().collect();
@@ -380,6 +380,7 @@ pub fn open_session(
             if let Err(e) = crate::daemon::client::destroy_daemon_session(
                 &daemon_result.daemon_session_id,
                 true,
+                kild_config,
             ) {
                 warn!(
                     event = "core.session.open_daemon_cleanup_failed",

--- a/crates/kild-core/src/state/dispatch.rs
+++ b/crates/kild-core/src/state/dispatch.rs
@@ -58,7 +58,7 @@ impl Store for CoreStore {
                 }])
             }
             Command::DestroyKild { branch, force } => {
-                session_ops::destroy_session(&branch, force)?;
+                session_ops::destroy_session(&branch, force, config)?;
                 Ok(vec![Event::KildDestroyed { branch }])
             }
             Command::OpenKild {
@@ -75,7 +75,7 @@ impl Store for CoreStore {
                 }])
             }
             Command::StopKild { branch } => {
-                session_ops::stop_session(&branch)?;
+                session_ops::stop_session(&branch, config)?;
                 Ok(vec![Event::KildStopped { branch }])
             }
             Command::CompleteKild { branch } => {

--- a/crates/kild/src/commands/agent_status.rs
+++ b/crates/kild/src/commands/agent_status.rs
@@ -7,7 +7,7 @@ use kild_core::errors::KildError;
 use kild_core::session_ops;
 
 pub(crate) fn handle_agent_status_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let use_self = matches.get_flag("self");
     let notify = matches.get_flag("notify");

--- a/crates/kild/src/commands/attach.rs
+++ b/crates/kild/src/commands/attach.rs
@@ -9,7 +9,7 @@ use tracing::{error, info, warn};
 use super::helpers;
 
 pub(crate) fn handle_attach_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")

--- a/crates/kild/src/commands/cd.rs
+++ b/crates/kild/src/commands/cd.rs
@@ -4,7 +4,7 @@ use tracing::{error, info};
 use super::helpers;
 use super::helpers::is_valid_branch_name;
 
-pub(crate) fn handle_cd_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_cd_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")
         .ok_or("Branch argument is required")?;

--- a/crates/kild/src/commands/cleanup.rs
+++ b/crates/kild/src/commands/cleanup.rs
@@ -7,7 +7,7 @@ use kild_core::events;
 use super::helpers::shorten_home_path;
 
 pub(crate) fn handle_cleanup_command(
-    sub_matches: &ArgMatches,
+    sub_matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(event = "cli.cleanup_started");
 

--- a/crates/kild/src/commands/code.rs
+++ b/crates/kild/src/commands/code.rs
@@ -6,7 +6,7 @@ use kild_core::editor::EditorError;
 use super::helpers::{self, load_config_with_warning, shorten_home_path};
 use crate::color;
 
-pub(crate) fn handle_code_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_code_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")
         .ok_or("Branch argument is required")?;

--- a/crates/kild/src/commands/commits.rs
+++ b/crates/kild/src/commands/commits.rs
@@ -6,7 +6,7 @@ use kild_core::events;
 use super::helpers;
 
 pub(crate) fn handle_commits_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::io::Write;
 

--- a/crates/kild/src/commands/complete.rs
+++ b/crates/kild/src/commands/complete.rs
@@ -7,7 +7,7 @@ use kild_core::session_ops;
 use super::helpers::is_valid_branch_name;
 
 pub(crate) fn handle_complete_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")

--- a/crates/kild/src/commands/completions.rs
+++ b/crates/kild/src/commands/completions.rs
@@ -4,7 +4,7 @@ use clap_complete::Shell;
 use crate::app::build_cli;
 
 pub(crate) fn handle_completions_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let shell = matches
         .get_one::<Shell>("shell")

--- a/crates/kild/src/commands/create.rs
+++ b/crates/kild/src/commands/create.rs
@@ -9,7 +9,7 @@ use super::helpers::{load_config_with_warning, resolve_runtime_mode, shorten_hom
 use crate::color;
 
 pub(crate) fn handle_create_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")

--- a/crates/kild/src/commands/daemon.rs
+++ b/crates/kild/src/commands/daemon.rs
@@ -2,7 +2,7 @@ use clap::ArgMatches;
 use tracing::{debug, error, info, warn};
 
 pub(crate) fn handle_daemon_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     match matches.subcommand() {
         Some(("start", sub)) => handle_daemon_start(sub),

--- a/crates/kild/src/commands/destroy.rs
+++ b/crates/kild/src/commands/destroy.rs
@@ -10,7 +10,7 @@ use super::helpers::{
 use crate::color;
 
 pub(crate) fn handle_destroy_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let force = matches.get_flag("force");
 

--- a/crates/kild/src/commands/diff.rs
+++ b/crates/kild/src/commands/diff.rs
@@ -7,7 +7,7 @@ use kild_core::git::get_diff_stats;
 use super::helpers;
 use super::helpers::shorten_home_path;
 
-pub(crate) fn handle_diff_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_diff_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")
         .ok_or("Branch argument is required")?;

--- a/crates/kild/src/commands/focus.rs
+++ b/crates/kild/src/commands/focus.rs
@@ -3,7 +3,7 @@ use tracing::{error, info};
 
 use super::helpers;
 
-pub(crate) fn handle_focus_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_focus_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")
         .ok_or("Branch argument is required")?;

--- a/crates/kild/src/commands/health.rs
+++ b/crates/kild/src/commands/health.rs
@@ -9,7 +9,7 @@ use super::helpers::{is_valid_branch_name, load_config_with_warning};
 use crate::table::{display_width, pad};
 
 pub(crate) fn handle_health_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches.get_one::<String>("branch");
     let json_output = matches.get_flag("json");

--- a/crates/kild/src/commands/hide.rs
+++ b/crates/kild/src/commands/hide.rs
@@ -9,7 +9,7 @@ use super::helpers::{
     self, FailedOperation, format_count, format_partial_failure_error, get_terminal_info, plural,
 };
 
-pub(crate) fn handle_hide_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_hide_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     if matches.get_flag("all") {
         return handle_hide_all();
     }

--- a/crates/kild/src/commands/init_hooks.rs
+++ b/crates/kild/src/commands/init_hooks.rs
@@ -4,7 +4,7 @@ use tracing::{info, warn};
 use crate::color;
 
 pub(crate) fn handle_init_hooks_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let agent = matches
         .get_one::<String>("agent")

--- a/crates/kild/src/commands/list.rs
+++ b/crates/kild/src/commands/list.rs
@@ -10,7 +10,7 @@ use kild_core::session_ops;
 use super::json_types::{EnrichedSession, FleetSummary, ListOutput};
 use crate::color;
 
-pub(crate) fn handle_list_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_list_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     let json_output = matches.get_flag("json");
 
     info!(event = "cli.list_started", json_output = json_output);

--- a/crates/kild/src/commands/mod.rs
+++ b/crates/kild/src/commands/mod.rs
@@ -34,39 +34,39 @@ mod stop;
 mod sync;
 mod teammates;
 
-pub fn run_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     events::log_app_startup();
 
     match matches.subcommand() {
-        Some(("create", sub_matches)) => create::handle_create_command(sub_matches),
-        Some(("list", sub_matches)) => list::handle_list_command(sub_matches),
-        Some(("cd", sub_matches)) => cd::handle_cd_command(sub_matches),
-        Some(("destroy", sub_matches)) => destroy::handle_destroy_command(sub_matches),
-        Some(("complete", sub_matches)) => complete::handle_complete_command(sub_matches),
-        Some(("completions", sub_matches)) => completions::handle_completions_command(sub_matches),
-        Some(("open", sub_matches)) => open::handle_open_command(sub_matches),
-        Some(("stop", sub_matches)) => stop::handle_stop_command(sub_matches),
-        Some(("code", sub_matches)) => code::handle_code_command(sub_matches),
-        Some(("focus", sub_matches)) => focus::handle_focus_command(sub_matches),
-        Some(("hide", sub_matches)) => hide::handle_hide_command(sub_matches),
-        Some(("diff", sub_matches)) => diff::handle_diff_command(sub_matches),
-        Some(("commits", sub_matches)) => commits::handle_commits_command(sub_matches),
-        Some(("pr", sub_matches)) => pr::handle_pr_command(sub_matches),
-        Some(("stats", sub_matches)) => stats::handle_stats_command(sub_matches),
-        Some(("overlaps", sub_matches)) => overlaps::handle_overlaps_command(sub_matches),
-        Some(("status", sub_matches)) => status::handle_status_command(sub_matches),
+        Some(("create", sub_matches)) => create::handle_create_command(sub_matches, config),
+        Some(("list", sub_matches)) => list::handle_list_command(sub_matches, config),
+        Some(("cd", sub_matches)) => cd::handle_cd_command(sub_matches, config),
+        Some(("destroy", sub_matches)) => destroy::handle_destroy_command(sub_matches, config),
+        Some(("complete", sub_matches)) => complete::handle_complete_command(sub_matches, config),
+        Some(("completions", sub_matches)) => completions::handle_completions_command(sub_matches, config),
+        Some(("open", sub_matches)) => open::handle_open_command(sub_matches, config),
+        Some(("stop", sub_matches)) => stop::handle_stop_command(sub_matches, config),
+        Some(("code", sub_matches)) => code::handle_code_command(sub_matches, config),
+        Some(("focus", sub_matches)) => focus::handle_focus_command(sub_matches, config),
+        Some(("hide", sub_matches)) => hide::handle_hide_command(sub_matches, config),
+        Some(("diff", sub_matches)) => diff::handle_diff_command(sub_matches, config),
+        Some(("commits", sub_matches)) => commits::handle_commits_command(sub_matches, config),
+        Some(("pr", sub_matches)) => pr::handle_pr_command(sub_matches, config),
+        Some(("stats", sub_matches)) => stats::handle_stats_command(sub_matches, config),
+        Some(("overlaps", sub_matches)) => overlaps::handle_overlaps_command(sub_matches, config),
+        Some(("status", sub_matches)) => status::handle_status_command(sub_matches, config),
         Some(("agent-status", sub_matches)) => {
-            agent_status::handle_agent_status_command(sub_matches)
+            agent_status::handle_agent_status_command(sub_matches, config)
         }
-        Some(("rebase", sub_matches)) => rebase::handle_rebase_command(sub_matches),
-        Some(("sync", sub_matches)) => sync::handle_sync_command(sub_matches),
-        Some(("cleanup", sub_matches)) => cleanup::handle_cleanup_command(sub_matches),
-        Some(("health", sub_matches)) => health::handle_health_command(sub_matches),
-        Some(("daemon", sub_matches)) => daemon::handle_daemon_command(sub_matches),
-        Some(("attach", sub_matches)) => attach::handle_attach_command(sub_matches),
-        Some(("teammates", sub_matches)) => teammates::handle_teammates_command(sub_matches),
-        Some(("init-hooks", sub_matches)) => init_hooks::handle_init_hooks_command(sub_matches),
-        Some(("project", sub_matches)) => project::handle_project_command(sub_matches),
+        Some(("rebase", sub_matches)) => rebase::handle_rebase_command(sub_matches, config),
+        Some(("sync", sub_matches)) => sync::handle_sync_command(sub_matches, config),
+        Some(("cleanup", sub_matches)) => cleanup::handle_cleanup_command(sub_matches, config),
+        Some(("health", sub_matches)) => health::handle_health_command(sub_matches, config),
+        Some(("daemon", sub_matches)) => daemon::handle_daemon_command(sub_matches, config),
+        Some(("attach", sub_matches)) => attach::handle_attach_command(sub_matches, config),
+        Some(("teammates", sub_matches)) => teammates::handle_teammates_command(sub_matches, config),
+        Some(("init-hooks", sub_matches)) => init_hooks::handle_init_hooks_command(sub_matches, config),
+        Some(("project", sub_matches)) => project::handle_project_command(sub_matches, config),
         _ => {
             error!(event = "cli.command_unknown");
             Err("Unknown command".into())

--- a/crates/kild/src/commands/open.rs
+++ b/crates/kild/src/commands/open.rs
@@ -10,7 +10,7 @@ use super::helpers::{
     resolve_explicit_runtime_mode, resolve_open_mode,
 };
 
-pub(crate) fn handle_open_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_open_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     let mode = resolve_open_mode(matches);
     let daemon_flag = matches.get_flag("daemon");
     let no_daemon_flag = matches.get_flag("no-daemon");

--- a/crates/kild/src/commands/overlaps.rs
+++ b/crates/kild/src/commands/overlaps.rs
@@ -6,7 +6,7 @@ use kild_core::session_ops;
 use super::helpers::{format_partial_failure_error, load_config_with_warning, plural};
 
 pub(crate) fn handle_overlaps_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let json_output = matches.get_flag("json");
     let config = load_config_with_warning();

--- a/crates/kild/src/commands/pr.rs
+++ b/crates/kild/src/commands/pr.rs
@@ -5,7 +5,7 @@ use kild_core::session_ops;
 
 use super::helpers::{self, is_valid_branch_name};
 
-pub(crate) fn handle_pr_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_pr_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")
         .ok_or("Branch argument is required")?;

--- a/crates/kild/src/commands/project.rs
+++ b/crates/kild/src/commands/project.rs
@@ -11,7 +11,7 @@ use kild_core::projects::{
 use crate::color;
 
 pub(crate) fn handle_project_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     match matches.subcommand() {
         Some(("add", sub)) => handle_project_add(sub),

--- a/crates/kild/src/commands/rebase.rs
+++ b/crates/kild/src/commands/rebase.rs
@@ -9,7 +9,7 @@ use super::helpers::{
 };
 
 pub(crate) fn handle_rebase_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     if matches.get_flag("all") {
         let base_override = matches.get_one::<String>("base").cloned();

--- a/crates/kild/src/commands/stats.rs
+++ b/crates/kild/src/commands/stats.rs
@@ -20,7 +20,7 @@ struct StatsOutput {
     merge_readiness: MergeReadiness,
 }
 
-pub(crate) fn handle_stats_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_stats_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     if matches.get_flag("all") {
         let base_override = matches.get_one::<String>("base").cloned();
         let json_output = matches.get_flag("json");

--- a/crates/kild/src/commands/status.rs
+++ b/crates/kild/src/commands/status.rs
@@ -11,7 +11,7 @@ use super::json_types::EnrichedSession;
 use crate::color;
 
 pub(crate) fn handle_status_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")

--- a/crates/kild/src/commands/stop.rs
+++ b/crates/kild/src/commands/stop.rs
@@ -8,7 +8,7 @@ use kild_core::session_ops;
 use super::helpers::{FailedOperation, format_count, format_partial_failure_error};
 use crate::color;
 
-pub(crate) fn handle_stop_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_stop_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(pane_id) = matches.get_one::<String>("pane") {
         let branch = matches
             .get_one::<String>("branch")

--- a/crates/kild/src/commands/sync.rs
+++ b/crates/kild/src/commands/sync.rs
@@ -8,7 +8,7 @@ use super::helpers::{
     load_config_with_warning,
 };
 
-pub(crate) fn handle_sync_command(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn handle_sync_command(matches: &ArgMatches, config: &kild_config::KildConfig) -> Result<(), Box<dyn std::error::Error>> {
     if matches.get_flag("all") {
         let base_override = matches.get_one::<String>("base").cloned();
         return handle_sync_all(base_override);

--- a/crates/kild/src/commands/teammates.rs
+++ b/crates/kild/src/commands/teammates.rs
@@ -9,7 +9,7 @@ use super::helpers;
 use crate::color;
 
 pub(crate) fn handle_teammates_command(
-    matches: &ArgMatches,
+    matches: &ArgMatches, config: &kild_config::KildConfig
 ) -> Result<(), Box<dyn std::error::Error>> {
     let branch = matches
         .get_one::<String>("branch")


### PR DESCRIPTION
Removes the global thread_local state for daemon remote overrides, plumbing the KildConfig directly into all daemon client IPC routines.