### PR TITLE
fix: detect stale daemon sessions after crash (#532)

### DIFF
--- a/crates/kild/src/commands/inject.rs
+++ b/crates/kild/src/commands/inject.rs
@@ -35,10 +35,8 @@ pub(crate) fn handle_inject_command(
 
     let mut session = helpers::require_session(branch, "cli.inject_failed")?;
 
-    // Sync daemon-managed sessions: if the daemon is unreachable (crash, socket gone),
-    // update status to Stopped so the check below blocks the inject.
-    // Structured daemon errors (e.g., unexpected error code) are not treated as
-    // unreachable — the "session_not_active" guard below still catches those via status.
+    // If the daemon crashed or the socket is gone, update status to Stopped
+    // so the active-session check below blocks the inject with a clear message.
     kild_core::session_ops::sync_daemon_session_status(&mut session);
 
     // Determine inject method: --inbox forces inbox protocol; otherwise use agent default.


### PR DESCRIPTION
## Summary

- **sync_daemon_session_status** now treats connection errors (broken pipe, empty response, connection failed) as "daemon unreachable" and syncs stale sessions to Stopped. Only `DaemonError` (structured error response) indicates the daemon is alive and skips the sync. Previously all errors were conservatively treated as "unknown, don't sync" — which left sessions marked Active when the daemon died mid-request.
- **kild inject** now calls `sync_daemon_session_status` before checking session status. Previously it loaded stale file-persisted status without syncing, so inject to a dead session would silently write to an unpolled inbox or fail confusingly.

Closes #532

## Test plan

- [x] New unit tests for `is_daemon_unreachable` covering all `DaemonClientError` variants
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes (all 25 test suites)
- [ ] Manual: `kild create test --daemon && kild daemon stop && kild list` → shows Stopped
- [ ] Manual: `kild create test --daemon && kill -9 <pid> && kild inject test "hi"` → errors with session not active