### PR TITLE
fix(cli): stop --all mentions already-stopped sessions

### DIFF
--- a/crates/kild/src/commands/stop.rs
+++ b/crates/kild/src/commands/stop.rs
@@ -164,14 +164,15 @@ fn handle_stop_all() -> Result<(), Box<dyn std::error::Error>> {
     // Report already-stopped sessions
     if !already_stopped.is_empty() {
         println!(
-            "{} already stopped: {}",
-            color::muted(&format_count(already_stopped.len())),
-            already_stopped
-                .iter()
-                .map(|s| s.branch.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
+            "{}",
+            color::muted(&format!(
+                "Already stopped {}:",
+                format_count(already_stopped.len())
+            ))
         );
+        for session in &already_stopped {
+            println!("  {}", color::ice(&session.branch));
+        }
     }
 
     info!(


### PR DESCRIPTION
## Summary

- `kild stop --all` now reports already-stopped sessions (e.g. `1 kild already stopped: my-branch`) so users can account for all sessions in the output
- Handles both cases: when all sessions are already stopped (no active to stop), and when there's a mix of active and stopped sessions

Closes #533

## Test plan

- [ ] Run `kild stop --all` with a mix of active and stopped sessions — verify stopped sessions are listed
- [ ] Run `kild stop --all` with only stopped sessions — verify the already-stopped message appears instead of "No running kilds to stop"
- [ ] Run `kild stop --all` with no sessions at all — verify "No running kilds to stop" still appears