### PR TITLE
fix(session): preserve agent_session_id on fresh open, clear idle gate on initial-prompt

### DIFF
--- a/crates/kild-core/src/sessions/daemon_request.rs
+++ b/crates/kild-core/src/sessions/daemon_request.rs
@@ -23,7 +23,8 @@ pub(super) struct DaemonSpawnParams {
 /// Detection: scrollback must exceed 50 bytes AND stop growing for 500ms.
 /// Write order: text → 50ms pause → `\r` (same cadence as `kild inject`).
 /// Never blocks the caller beyond 20s. Never fails — logs and returns on any error.
-/// Returns `true` if the prompt text was successfully written to the PTY.
+/// Returns `true` if the prompt text bytes were written to the PTY.
+/// The subsequent Enter keystroke (`\r`) is best-effort and does not affect the return value.
 pub(super) fn deliver_initial_prompt(daemon_session_id: &str, prompt: &str) -> bool {
     let timeout = std::time::Duration::from_secs(20);
     let poll_interval = std::time::Duration::from_millis(200);

--- a/crates/kild-core/src/sessions/dropbox.rs
+++ b/crates/kild-core/src/sessions/dropbox.rs
@@ -510,12 +510,10 @@ pub(super) fn clear_idle_gate(project_id: &str, branch: &str) {
         }
     };
 
-    remove_idle_gate_file(
-        &paths
-            .fleet_dropbox_dir(project_id, branch)
-            .join(".idle_sent"),
-        branch,
-    );
+    let gate_path = paths
+        .fleet_dropbox_dir(project_id, branch)
+        .join(".idle_sent");
+    remove_idle_gate_file(&gate_path, branch);
 }
 
 /// Inject `KILD_DROPBOX` (and `KILD_FLEET_DIR` for brain) into daemon env vars.

--- a/crates/kild-core/src/sessions/types/session.rs
+++ b/crates/kild-core/src/sessions/types/session.rs
@@ -198,6 +198,23 @@ impl Session {
         self.agents = agents;
     }
 
+    /// Rotate agent_session_id, preserving the previous ID in history.
+    ///
+    /// No-op on the history if the new ID is identical to the current one (resume path).
+    /// Returns `true` if the previous ID was different and moved to history.
+    pub fn rotate_agent_session_id(&mut self, new_id: String) -> bool {
+        let rotated = if let Some(prev) = self.agent_session_id.take()
+            && prev != new_id
+        {
+            self.agent_session_id_history.push(prev);
+            true
+        } else {
+            false
+        };
+        self.agent_session_id = Some(new_id);
+        rotated
+    }
+
     /// Create a minimal Session for testing purposes.
     #[cfg(test)]
     pub fn new_for_test(branch: impl Into<BranchName>, worktree_path: PathBuf) -> Self {


### PR DESCRIPTION
## Summary

- **#572**: `kild open` without `--resume` now preserves the previous `agent_session_id` in a new `agent_session_id_history` field before overwriting. Emits a warning log so the user knows the old conversation is being rotated out. Previous sessions remain recoverable via the history.
- **#573**: `kild open --initial-prompt` now clears the `.idle_sent` gate file in the dropbox after `deliver_initial_prompt()`. This ensures the brain gets notified when the worker finishes, matching the existing clearing logic in `dropbox::write_task()`.

Closes #572
Closes #573

## Test plan

- [x] `cargo fmt --check` — 0 violations
- [x] `cargo clippy --all -- -D warnings` — 0 warnings
- [x] `cargo test --all` — all tests pass
- [x] New tests for `agent_session_id_history` (serialization round-trip, no duplicate on resume, multi-open accumulation, empty history not serialized)
- [x] New tests for `clear_idle_gate` (removes existing gate, noop when absent, noop when fleet not active)