### PR TITLE
fix(forge,cli): normalize branch names in GitHub backend, spawn attach window for headless sessions

### DIFF
--- a/crates/kild-core/src/forge/backends/github.rs
+++ b/crates/kild-core/src/forge/backends/github.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info, warn};
 use crate::forge::errors::ForgeError;
 use crate::forge::traits::ForgeBackend;
 use crate::forge::types::{CiStatus, PrCheckResult, PrInfo, PrState, ReviewStatus};
-use crate::git::naming::KILD_BRANCH_PREFIX;
+use crate::git::naming::{KILD_BRANCH_PREFIX, kild_branch_name};
 
 /// GitHub forge backend using the `gh` CLI.
 pub struct GitHubBackend;
@@ -22,7 +22,7 @@ fn normalize_branch(branch: &str) -> Cow<'_, str> {
     if branch.starts_with(KILD_BRANCH_PREFIX) {
         Cow::Borrowed(branch)
     } else {
-        Cow::Owned(crate::git::naming::kild_branch_name(branch))
+        Cow::Owned(kild_branch_name(branch))
     }
 }
 

--- a/crates/kild/src/commands/attach.rs
+++ b/crates/kild/src/commands/attach.rs
@@ -69,20 +69,20 @@ pub(crate) fn handle_attach_command(
         );
 
         let kild_config = helpers::load_config_with_warning();
-        let config = kild_config::Config::new();
+        let sessions_dir = kild_config::Config::new().sessions_dir();
 
         match kild_core::sessions::daemon_helpers::spawn_and_save_attach_window(
             &mut session,
             branch,
             &kild_config,
-            &config.sessions_dir(),
+            &sessions_dir,
         ) {
             Ok(true) => {
                 info!(event = "cli.attach_window_spawned", branch = branch);
                 return Ok(());
             }
             Ok(false) => {
-                // Window spawn failed (best-effort), fall through to direct attach
+                // Terminal backend returned no window ID (best-effort), fall through to direct attach
                 warn!(
                     event = "cli.attach_window_spawn_failed",
                     branch = branch,


### PR DESCRIPTION
## Summary

- **#569**: GitHub forge backend now normalizes branch names to include the `kild/` prefix before querying `gh pr view`. This prevents "no pull requests found" errors when short branch names are passed, fixing `kild stats` reporting "Needs PR" for branches with existing PRs.
- **#549**: `kild attach` on headless daemon sessions (opened with `--no-attach`) now spawns a new terminal window via the configured terminal backend. Falls back to direct daemon attach if window spawn fails.

## Changes

- `crates/kild-core/src/forge/backends/github.rs`: Added `normalize_branch()` helper that ensures `kild/` prefix (idempotent — preserves existing prefix). Applied to all three trait methods: `is_pr_merged`, `check_pr_exists`, `fetch_pr_info`. Added tests.
- `crates/kild/src/commands/attach.rs`: Detect headless sessions (has daemon_session_id but no terminal window) and spawn a new attach window via `spawn_and_save_attach_window`. Graceful fallback to direct attach on failure.

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --all -- -D warnings` — passes
- [x] `cargo test --all` — all tests pass
- [ ] Manual: `kild open <branch> --no-attach --resume` then `kild attach <branch>` spawns a window
- [ ] Manual: `kild stats <branch>` correctly reports PR status for branches with existing PRs

Fixes #569, fixes #549