### PR TITLE
fix(daemon): skip scrollback replay when PTY dimensions changed on attach

### DIFF
--- a/crates/kild-daemon/src/server/connection.rs
+++ b/crates/kild-daemon/src/server/connection.rs
@@ -157,13 +157,23 @@ where
             rows,
             cols,
         } => {
-            let (rx, scrollback, resize_failed) = {
+            let (rx, scrollback, resize_failed, size_changed) = {
                 let mut mgr = session_manager.write().await;
 
                 // Read current PTY size before resize to detect dimension changes.
+                // Both calls must occur under the same write lock to avoid a TOCTOU
+                // race where another client resizes between the two operations.
                 // Scrollback rendered at different dimensions produces garbled output
                 // when replayed — skip replay if the resize actually changed the size.
                 let old_size = mgr.pty_size(&session_id);
+
+                if old_size.is_none() {
+                    warn!(
+                        event = "daemon.connection.pty_size_unavailable",
+                        session_id = %session_id,
+                        "PTY not found when reading pre-attach size; session may have stopped mid-attach",
+                    );
+                }
 
                 // Resize to client dimensions
                 let resize_failed = if let Err(e) = mgr.resize_pty(&session_id, rows, cols) {
@@ -199,9 +209,10 @@ where
 
                 // Skip scrollback replay when dimensions changed — the buffer contains
                 // escape sequences rendered at the old size which produce garbled output
-                // in the new terminal. The agent will re-render via SIGWINCH.
+                // in the new terminal. The resize above already delivered SIGWINCH to the
+                // child (via the PTY master resize syscall), which will trigger a re-render.
                 let scrollback = if size_changed {
-                    debug!(
+                    info!(
                         event = "daemon.connection.scrollback_skipped",
                         session_id = %session_id,
                         old_size = ?old_size,
@@ -225,7 +236,7 @@ where
                     }
                 };
 
-                (rx, scrollback, resize_failed)
+                (rx, scrollback, resize_failed, size_changed)
             };
 
             // Hold the writer lock for ack + scrollback + buffered drain so
@@ -247,16 +258,39 @@ where
 
                 // Notify client if resize failed (non-fatal, no flush)
                 if resize_failed {
+                    let msg = if size_changed {
+                        "Terminal resize failed and scrollback was skipped due to dimension mismatch. \
+                         The agent will re-render when resize succeeds."
+                    } else {
+                        "Terminal resize failed. Display may be garbled. Try detaching and reattaching."
+                    };
                     let resize_warning = DaemonMessage::SessionEvent {
                         event: "resize_failed".to_string(),
                         session_id: session_id.clone(),
-                        details: Some(serde_json::json!({
-                            "message": "Terminal resize failed. Display may be garbled. Try detaching and reattaching."
-                        })),
+                        details: Some(serde_json::json!({ "message": msg })),
                     };
                     if let Err(e) = write_message(&mut *w, &resize_warning).await {
                         warn!(
                             event = "daemon.connection.resize_warning_write_failed",
+                            session_id = %session_id,
+                            client_id = client_id,
+                            error = %e,
+                        );
+                    }
+                }
+
+                // Notify client when scrollback was skipped due to dimension change
+                if size_changed && !resize_failed {
+                    let skip_notice = DaemonMessage::SessionEvent {
+                        event: "scrollback_skipped".to_string(),
+                        session_id: session_id.clone(),
+                        details: Some(serde_json::json!({
+                            "message": "Scrollback replay skipped: terminal dimensions changed. The agent will re-render output."
+                        })),
+                    };
+                    if let Err(e) = write_message(&mut *w, &skip_notice).await {
+                        warn!(
+                            event = "daemon.connection.scrollback_skip_notice_write_failed",
                             session_id = %session_id,
                             client_id = client_id,
                             error = %e,

--- a/crates/kild-daemon/src/session/manager.rs
+++ b/crates/kild-daemon/src/session/manager.rs
@@ -208,12 +208,18 @@ impl SessionManager {
         pty.resize(rows, cols)
     }
 
-    /// Get the current PTY dimensions for a session.
+    /// Get the cached PTY dimensions for a session.
+    ///
+    /// Returns `Some((rows, cols))` if the session has an active PTY.
+    /// Returns `None` if no PTY is registered for `session_id` (e.g. the session
+    /// was never started, has already been stopped, or was removed mid-flight).
+    ///
+    /// Returns the dimensions last successfully set via [`resize_pty`], which
+    /// match the PTY creation size initially. Does **not** query the kernel.
     pub fn pty_size(&self, session_id: &str) -> Option<(u16, u16)> {
-        self.pty_manager.get(session_id).map(|pty| {
-            let size = pty.size();
-            (size.rows, size.cols)
-        })
+        self.pty_manager
+            .get(session_id)
+            .map(|pty| (pty.size().rows, pty.size().cols))
     }
 
     /// Write data to a session's PTY stdin.


### PR DESCRIPTION
## Summary

- Daemon PTYs spawn at hardcoded 24×80 before any terminal window exists — scrollback fills with 80-column escape sequences
- When the attach window connects at actual dimensions (e.g., 220×55), stale scrollback was replayed verbatim, producing garbled layout
- Now the attach handler compares PTY dimensions before/after resize and skips scrollback replay when they changed — the agent re-renders correctly via SIGWINCH

## Changes

| File | Change |
|------|--------|
| `crates/kild-daemon/src/session/manager.rs` | Add `pty_size()` accessor to expose current PTY dimensions |
| `crates/kild-daemon/src/server/connection.rs` | Compare pre/post resize dimensions; skip scrollback when changed |
| `crates/kild-daemon/src/session/manager.rs` | Add tests for `pty_size()` |

## Testing

- [x] `cargo fmt --check` — 0 violations
- [x] `cargo clippy --all -- -D warnings` — 0 warnings
- [x] `cargo test --all` — all pass (2 new tests for `pty_size`)
- [ ] Manual: `kild create test --daemon` — verify clean rendering in auto-attach window
- [ ] Manual: `kild attach test` from different-sized terminal — no garbled output
- [ ] Manual: Reattach at same size — scrollback replays normally

## Validation

```bash
cargo fmt --check && cargo clippy --all -- -D warnings && cargo test --all
```

Fixes #601