### PR TITLE
fix(fleet): store augmented command in session file

### DIFF
--- a/crates/kild-core/src/sessions/daemon_spawn.rs
+++ b/crates/kild-core/src/sessions/daemon_spawn.rs
@@ -38,6 +38,9 @@ pub(super) struct AgentSpawnParams<'a> {
 /// Handles the shared daemon spawn sequence: daemon startup, agent hook setup,
 /// fleet wiring, PTY creation, and early-exit detection.
 ///
+/// The returned `AgentProcess::command` contains the fleet-augmented command
+/// (base agent command + fleet flags), matching what the daemon actually executes.
+///
 /// Create-only steps (shim binary, pre-emptive cleanup, pane registry init)
 /// and open-only steps (initial prompt delivery) remain in their respective callers.
 pub(super) fn spawn_daemon_agent(


### PR DESCRIPTION
## Summary

- `kild list` showed the base agent command without fleet flags (`--agent-id`, `--agent-name`, `--team-name`) because `AgentProcess` stored the command *before* `fleet_agent_flags()` appended them
- Use the already-computed `fleet_command` (which includes fleet flags when applicable) instead of the base `agent_command` when constructing `AgentProcess`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes (3 pre-existing env-dependent test failures unrelated to this change)
- [ ] Create a fleet worker session, verify `kild list --json` shows the full command including `--agent-id`, `--agent-name`, `--team-name`

Closes #607