### PR TITLE
feat(ui): add cursor blink support

### DIFF
--- a/crates/kild-ui/src/terminal/blink.rs
+++ b/crates/kild-ui/src/terminal/blink.rs
@@ -8,14 +8,19 @@ const BLINK_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Manages cursor blink state with epoch-based timer cancellation.
 ///
-/// Each call to `enable()` or `pause()` increments the epoch and spawns a new
-/// async blink cycle via `cx.spawn()` on the owning `TerminalView`. Old cycles
-/// detect the stale epoch and exit, so at most one timer drives repaints.
-pub struct BlinkManager {
+/// Constructed in an inert state. Call `enable()` to start blinking and
+/// `disable()` to stop. `TerminalView` drives the lifecycle from `render()`
+/// based on focus state — blinking only runs while the terminal is focused.
+///
+/// Each `enable()` or `reset()` call increments the epoch and spawns a new
+/// async blink cycle via `cx.spawn()`. Old cycles detect the stale epoch
+/// and exit, so at most one timer drives repaints.
+pub(super) struct BlinkManager {
     visible: bool,
     enabled: bool,
     epoch: usize,
-    /// Stored to prevent cancellation of the current blink timer task.
+    /// Dropping a GPUI `Task` detaches it (the future keeps running until it
+    /// exits). Stored here so the current cycle is accessible for replacement.
     _task: Option<Task<()>>,
 }
 
@@ -30,8 +35,15 @@ impl BlinkManager {
     }
 
     /// Whether the cursor should be painted this frame.
+    ///
+    /// Returns `true` when blinking is disabled (cursor always on) or when
+    /// the blink cycle is in its visible phase.
     pub fn visible(&self) -> bool {
         !self.enabled || self.visible
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
     }
 
     /// Start blinking. Resets visibility and spawns a new blink cycle.
@@ -41,16 +53,35 @@ impl BlinkManager {
         self.start_cycle(cx);
     }
 
-    /// Show the cursor immediately and restart the blink timer.
+    /// Stop blinking and keep the cursor permanently visible.
+    pub fn disable(&mut self) {
+        self.enabled = false;
+        self.visible = true;
+        self.epoch = self.epoch.wrapping_add(1);
+        self._task = None;
+    }
+
+    /// Reset cursor to visible and restart the blink timer from zero.
     ///
-    /// Call on every keystroke so the cursor stays visible during typing
-    /// and only starts blinking again after a full interval of inactivity.
-    pub fn pause(&mut self, cx: &mut Context<TerminalView>) {
+    /// Call on every keystroke so the cursor stays solid during typing and
+    /// only resumes blinking after a full 500ms of inactivity.
+    pub fn reset(&mut self, cx: &mut Context<TerminalView>) {
         if !self.enabled {
             return;
         }
         self.visible = true;
         self.start_cycle(cx);
+    }
+
+    /// Toggle visibility if this cycle is still current. Returns `false` when
+    /// the epoch is stale, signaling the caller to exit the blink loop.
+    fn toggle_if_current(&mut self, epoch: usize, cx: &mut Context<TerminalView>) -> bool {
+        if self.epoch != epoch {
+            return false;
+        }
+        self.visible = !self.visible;
+        cx.notify();
+        true
     }
 
     fn start_cycle(&mut self, cx: &mut Context<TerminalView>) {
@@ -61,16 +92,11 @@ impl BlinkManager {
             loop {
                 cx.background_executor().timer(BLINK_INTERVAL).await;
 
-                let should_continue = this
-                    .update(cx, |view, cx| {
-                        if view.blink.epoch != epoch {
-                            return false;
-                        }
-                        view.blink.visible = !view.blink.visible;
-                        cx.notify();
-                        true
-                    })
-                    .unwrap_or(false);
+                let should_continue =
+                    match this.update(cx, |view, cx| view.blink.toggle_if_current(epoch, cx)) {
+                        Ok(cont) => cont,
+                        Err(_) => break, // view released — normal teardown
+                    };
 
                 if !should_continue {
                     break;

--- a/crates/kild-ui/src/terminal/mod.rs
+++ b/crates/kild-ui/src/terminal/mod.rs
@@ -1,4 +1,4 @@
-pub mod blink;
+mod blink;
 pub mod colors;
 pub mod errors;
 pub mod input;


### PR DESCRIPTION
## Summary
- Add `BlinkManager` with epoch-based timer to toggle cursor visibility every 500ms
- Pause blink on keystroke so cursor stays visible during typing
- Unfocused terminals show a static hollow block (no blinking)

## Test plan
- [ ] Open kild-ui, verify cursor blinks at ~500ms intervals when idle
- [ ] Type in terminal, confirm cursor stays solid during input and resumes blinking after pause
- [ ] Switch focus away from terminal, verify cursor becomes a static hollow block
- [ ] Open multiple terminals, confirm each has independent blink state

Closes #471