### PR TITLE
perf: process kill wait loop and PID polling jitter

### DIFF
--- a/crates/kild-core/src/process/operations.rs
+++ b/crates/kild-core/src/process/operations.rs
@@ -112,24 +112,20 @@ pub fn kill_process(
 
             // Best-effort wait: give the process up to 500ms to exit after
             // SIGKILL. Reuses the existing `system` to avoid repeated allocations.
-            let mut exited = false;
-            let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
-            while std::time::Instant::now() < deadline {
+            let start = std::time::Instant::now();
+            while start.elapsed() < std::time::Duration::from_millis(500) {
                 system.refresh_processes(ProcessesToUpdate::Some(&[pid_obj]), true);
                 if system.process(pid_obj).is_none() {
-                    exited = true;
-                    break;
+                    return Ok(());
                 }
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
 
-            if !exited {
-                debug!(
-                    event = "core.process.kill_wait_timeout",
-                    pid = pid,
-                    message = "process did not exit within 500ms after SIGKILL"
-                );
-            }
+            debug!(
+                event = "core.process.kill_wait_timeout",
+                pid = pid,
+                message = "process did not exit within 500ms after SIGKILL"
+            );
 
             Ok(())
         }

--- a/crates/kild-core/src/process/pid_file.rs
+++ b/crates/kild-core/src/process/pid_file.rs
@@ -47,12 +47,11 @@ pub fn read_pid_file_with_retry(pid_file: &Path) -> Result<Option<u32>, ProcessE
     const BASE_INTERVAL_MS: u64 = 100;
     const MAX_WAIT: Duration = Duration::from_secs(3);
 
-    // Compute jitter once — deterministic per-process, varies across concurrent launches
-    let jitter_range = BASE_INTERVAL_MS / 5; // 20ms
-    let pid_jitter = (std::process::id() as u64) % (jitter_range * 2 + 1);
-    let jitter = pid_jitter as i64 - jitter_range as i64;
-    // poll_interval is in [80, 120] ms — cannot underflow
-    let poll_interval = Duration::from_millis((BASE_INTERVAL_MS as i64 + jitter) as u64);
+    // Compute jitter once — deterministic per-process, varies across concurrent launches.
+    // Maps PID to [0, 40], subtracts 20 → poll_interval in [80, 120] ms (no underflow).
+    const JITTER_RANGE_MS: u64 = BASE_INTERVAL_MS / 5; // 20ms
+    let pid_offset = (std::process::id() as u64) % (JITTER_RANGE_MS * 2 + 1);
+    let poll_interval = Duration::from_millis(BASE_INTERVAL_MS + pid_offset - JITTER_RANGE_MS);
 
     let start = std::time::Instant::now();
     let mut last_error: Option<ProcessError> = None;


### PR DESCRIPTION
## Summary

- Add best-effort wait after `kill()` — polls for up to 500ms to verify process termination, logs timeout if process survives SIGKILL
- Add +/-20% PID-based jitter to PID file polling interval to decorrelate simultaneous `kild create` launches

Items 1 (Cow newtypes), 2 (git caching — each call opens a different worktree path), 3 (current_thread runtime — reverted, daemon runs fine on multi-threaded), and 6 (HashMap keys are tiny pane IDs) from #478 were evaluated and skipped as YAGNI for this codebase.

Closes #478

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes (2 pre-existing failures in `resolve_self_branch` unrelated to this PR)
- [ ] Manual test: `kild create` + `kild stop` to verify process cleanup
- [ ] Manual test: concurrent `kild create` commands to verify jitter prevents lock contention