### PR TITLE
fix(daemon): restore pooled connection timeout after short-timeout operations

### DIFF
--- a/crates/kild-core/src/daemon/client.rs
+++ b/crates/kild-core/src/daemon/client.rs
@@ -341,12 +341,12 @@ pub fn ping_daemon() -> Result<bool, DaemonClientError> {
         Err(e) => return Err(e),
     };
 
-    let orig_timeout = conn.get_read_timeout()?;
-    conn.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let (result, restored) =
+        conn.with_read_timeout(Duration::from_secs(2), |c| c.send(&request))?;
 
-    match conn.send(&request) {
+    match result {
         Ok(_) => {
-            if conn.set_read_timeout(orig_timeout).is_ok() {
+            if restored {
                 return_connection(conn);
             }
             debug!(event = "core.daemon.ping_completed", alive = true);
@@ -394,12 +394,12 @@ pub fn get_session_status(
         }
     };
 
-    let orig_timeout = conn.get_read_timeout()?;
-    conn.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let (result, restored) =
+        conn.with_read_timeout(Duration::from_secs(2), |c| c.send(&request))?;
 
-    match conn.send(&request) {
+    match result {
         Ok(DaemonMessage::SessionInfo { session, .. }) => {
-            if conn.set_read_timeout(orig_timeout).is_ok() {
+            if restored {
                 return_connection(conn);
             }
             debug!(
@@ -421,7 +421,7 @@ pub fn get_session_status(
             })
         }
         Err(IpcError::DaemonError { ref code, .. }) if *code == ErrorCode::SessionNotFound => {
-            if conn.set_read_timeout(orig_timeout).is_ok() {
+            if restored {
                 return_connection(conn);
             }
             debug!(
@@ -461,12 +461,12 @@ pub fn get_session_info(
         Err(e) => return Err(e),
     };
 
-    let orig_timeout = conn.get_read_timeout()?;
-    conn.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let (result, restored) =
+        conn.with_read_timeout(Duration::from_secs(2), |c| c.send(&request))?;
 
-    match conn.send(&request) {
+    match result {
         Ok(DaemonMessage::SessionInfo { session, .. }) => {
-            if conn.set_read_timeout(orig_timeout).is_ok() {
+            if restored {
                 return_connection(conn);
             }
             Ok(Some((session.status, session.exit_code)))
@@ -483,7 +483,7 @@ pub fn get_session_info(
             })
         }
         Err(IpcError::DaemonError { ref code, .. }) if *code == ErrorCode::SessionNotFound => {
-            if conn.set_read_timeout(orig_timeout).is_ok() {
+            if restored {
                 return_connection(conn);
             }
             Ok(None)
@@ -571,12 +571,12 @@ pub fn read_scrollback(daemon_session_id: &str) -> Result<Option<Vec<u8>>, Daemo
         Err(e) => return Err(e),
     };
 
-    let orig_timeout = conn.get_read_timeout()?;
-    conn.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let (result, restored) =
+        conn.with_read_timeout(Duration::from_secs(2), |c| c.send(&request))?;
 
-    match conn.send(&request) {
+    match result {
         Ok(DaemonMessage::ScrollbackContents { data, .. }) => {
-            if conn.set_read_timeout(orig_timeout).is_ok() {
+            if restored {
                 return_connection(conn);
             }
             use base64::Engine;
@@ -599,7 +599,7 @@ pub fn read_scrollback(daemon_session_id: &str) -> Result<Option<Vec<u8>>, Daemo
             })
         }
         Err(IpcError::DaemonError { ref code, .. }) if *code == ErrorCode::SessionNotFound => {
-            if conn.set_read_timeout(orig_timeout).is_ok() {
+            if restored {
                 return_connection(conn);
             }
             Ok(None)

--- a/crates/kild-protocol/src/client.rs
+++ b/crates/kild-protocol/src/client.rs
@@ -250,6 +250,35 @@ impl IpcConnection {
         }
     }
 
+    /// Temporarily override the read timeout, run `f`, then restore the
+    /// original timeout.
+    ///
+    /// Returns `(T, bool)` where the bool indicates whether the original
+    /// timeout was successfully restored. When `false` the connection is in
+    /// an unknown timeout state and should **not** be returned to the pool.
+    ///
+    /// ```ignore
+    /// let (result, restored) = conn.with_read_timeout(
+    ///     Duration::from_secs(2),
+    ///     |c| c.send(&msg),
+    /// )?;
+    /// if restored { return_connection(conn); }
+    /// ```
+    pub fn with_read_timeout<F, T>(
+        &mut self,
+        timeout: Duration,
+        f: F,
+    ) -> Result<(T, bool), IpcError>
+    where
+        F: FnOnce(&mut Self) -> T,
+    {
+        let orig = self.get_read_timeout()?;
+        self.set_read_timeout(Some(timeout))?;
+        let result = f(self);
+        let restored = self.set_read_timeout(orig).is_ok();
+        Ok((result, restored))
+    }
+
     /// Check if the connection is still usable (peer hasn't closed).
     ///
     /// For Unix streams: temporarily sets a 1ms read timeout (restored via RAII
@@ -525,6 +554,48 @@ mod tests {
             .unwrap();
         let timeout = conn.get_read_timeout().unwrap();
         assert_eq!(timeout, Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn test_with_read_timeout_restores_original() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = std::io::BufReader::new(&stream);
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let response = r#"{"type":"ack","id":"1"}"#;
+            writeln!(stream, "{}", response).unwrap();
+            stream.flush().unwrap();
+            // Keep stream alive so peer doesn't see EOF before restore
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        });
+
+        let mut conn = IpcConnection::connect(&sock_path).unwrap();
+        assert_eq!(
+            conn.get_read_timeout().unwrap(),
+            Some(Duration::from_secs(30))
+        );
+
+        let request = ClientMessage::Ping {
+            id: "1".to_string(),
+        };
+        let (result, restored) = conn
+            .with_read_timeout(Duration::from_secs(2), |c| c.send(&request))
+            .unwrap();
+
+        assert!(result.is_ok(), "send should succeed");
+        assert!(restored, "timeout should be restored");
+        assert_eq!(
+            conn.get_read_timeout().unwrap(),
+            Some(Duration::from_secs(30)),
+            "original timeout should be restored after with_read_timeout"
+        );
+
+        handle.join().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Four functions (`ping_daemon`, `get_session_status`, `get_session_info`, `read_scrollback`) set a 2s read timeout on pooled IPC connections but never restored the 30s default before returning to the pool — the next caller on the same thread inherited the corrupted timeout
- Save original timeout before override, restore before pool return; if restore fails, drop the connection instead of poisoning the pool
- Add `IpcConnection::get_read_timeout()` getter to support the save/restore pattern

## Test plan

- [x] New unit test `test_get_read_timeout_returns_current_value` verifies round-trip save/set/restore
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes (all 27 test suites)
- [x] `cargo build --all` passes