### PR TITLE
fix(shim): hold registry lock across load-modify-save to prevent pane ID races

### DIFF
--- a/crates/kild-tmux-shim/src/commands.rs
+++ b/crates/kild-tmux-shim/src/commands.rs
@@ -322,7 +322,11 @@ fn handle_split_window(args: SplitWindowArgs<'_>) -> Result<i32, ShimError> {
             .get(&window_id)
             .map(|w| w.name.clone())
             .unwrap_or_else(|| "main".to_string());
-        Some((args.format.unwrap_or("#{pane_id}"), session_name, window_name))
+        Some((
+            args.format.unwrap_or("#{pane_id}"),
+            session_name,
+            window_name,
+        ))
     } else {
         None
     };
@@ -667,18 +671,18 @@ fn handle_new_session(args: NewSessionArgs<'_>) -> Result<i32, ShimError> {
     let sid = session_id()?;
     let mut locked = state::load_and_lock(&sid)?;
 
+    // Read phase: derive names and IDs from current state
     let session_name = args
         .session_name
         .map(|s| s.to_string())
         .unwrap_or_else(|| format!("kild_{}", locked.registry().sessions.len()));
-
     let window_name = args
         .window_name
         .map(|s| s.to_string())
         .unwrap_or_else(|| "main".to_string());
-
-    // Allocate a new window
     let window_id = format!("{}", locked.registry().windows.len());
+
+    // Write phase: mutate registry
     locked.registry_mut().windows.insert(
         window_id.clone(),
         WindowEntry {
@@ -724,8 +728,16 @@ fn handle_new_window(args: NewWindowArgs<'_>) -> Result<i32, ShimError> {
         .name
         .map(|s| s.to_string())
         .unwrap_or_else(|| "window".to_string());
-    let window_id = format!("{}", locked.registry().windows.len());
 
+    // Read phase: derive IDs from current state
+    let window_id = format!("{}", locked.registry().windows.len());
+    let session_key = args
+        .target
+        .and_then(|t| t.split(':').next())
+        .unwrap_or(&locked.registry().session_name)
+        .to_string();
+
+    // Write phase: mutate registry
     locked.registry_mut().windows.insert(
         window_id.clone(),
         WindowEntry {
@@ -735,13 +747,6 @@ fn handle_new_window(args: NewWindowArgs<'_>) -> Result<i32, ShimError> {
     );
 
     let pane_id = create_pty_pane(locked.registry_mut(), &window_id, &[])?;
-
-    // Add window to the target session (or default session)
-    let session_key = args
-        .target
-        .and_then(|t| t.split(':').next())
-        .unwrap_or(&locked.registry().session_name)
-        .to_string();
 
     if let Some(session) = locked.registry_mut().sessions.get_mut(&session_key) {
         session.windows.push(window_id.clone());

--- a/crates/kild-tmux-shim/src/state.rs
+++ b/crates/kild-tmux-shim/src/state.rs
@@ -8,8 +8,10 @@
 //!   and return a `LockedRegistry` guard. The lock is held across the entire
 //!   load → mutate → save cycle, preventing pane ID races from concurrent
 //!   `split-window` calls. Call `locked.save()` to persist and release.
-//! - **Legacy writes**: `load()` + `save()` each acquire independent locks.
-//!   Only use for initialization paths where atomicity is not required.
+//! - **Init only**: `save()` acquires its own exclusive lock. Only used by
+//!   `init_registry()` where atomic load-modify-save is not needed.
+//! - **Test only**: `load()` acquires an exclusive lock for a single read.
+//!   Gated behind `#[cfg(test)]`.
 //!
 //! Locks are automatically released when the `Flock` handle is dropped (RAII).
 


### PR DESCRIPTION
## Summary

- Add `LockedRegistry` guard type in `state.rs` holding both `Flock<File>` and `PaneRegistry`
- `load_and_lock()` acquires exclusive flock + reads registry atomically, returns guard
- `save(self)` writes while lock is still held, then consumes guard (lock drops)
- Update all 8 callers in `commands.rs`: `handle_split_window`, `handle_kill_pane`, `handle_select_pane`, `handle_set_option`, `handle_new_session`, `handle_new_window`, `handle_break_pane`, `handle_join_pane`
- Add thread-level concurrency test verifying unique pane ID allocation under parallel access

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test -p kild-tmux-shim` passes (including new concurrency test)
- [x] `cargo build --all` passes