### PR TITLE
feat(ui): add terminal reconnection on daemon disconnect

### DIFF
--- a/crates/kild-ui/src/terminal/state.rs
+++ b/crates/kild-ui/src/terminal/state.rs
@@ -830,10 +830,22 @@ impl Terminal {
             .unwrap_or(ReconnectState::Idle)
     }
 
+    /// Current PTY dimensions (rows, cols).
+    pub fn current_size(&self) -> (u16, u16) {
+        self.current_size.lock().map(|s| *s).unwrap_or((24, 80))
+    }
+
     /// Update the reconnection state.
     pub fn set_reconnect_state(&self, state: ReconnectState) {
-        if let Ok(mut s) = self.reconnect_state.lock() {
-            *s = state;
+        match self.reconnect_state.lock() {
+            Ok(mut s) => *s = state,
+            Err(e) => {
+                tracing::error!(
+                    event = "ui.terminal.reconnect_state_lock_poisoned",
+                    error = %e,
+                    "Could not update reconnect state — lock poisoned"
+                );
+            }
         }
     }
 }

--- a/crates/kild-ui/src/terminal/terminal_view.rs
+++ b/crates/kild-ui/src/terminal/terminal_view.rs
@@ -225,16 +225,16 @@ impl TerminalView {
             event = "ui.terminal.reconnect_started",
             session_id = session_id
         );
-        self.terminal.set_reconnect_state(ReconnectState::Connecting);
+        self.terminal
+            .set_reconnect_state(ReconnectState::Connecting);
+        let (rows, cols) = self.terminal.current_size();
         cx.notify();
 
         let task = cx.spawn(async move |this, cx: &mut gpui::AsyncApp| {
             let sid = session_id.clone();
             let conn_result = cx
                 .background_executor()
-                .spawn(async move {
-                    daemon_client::connect_for_attach(&sid, 24, 80).await
-                })
+                .spawn(async move { daemon_client::connect_for_attach(&sid, rows, cols).await })
                 .await;
 
             match conn_result {
@@ -246,7 +246,8 @@ impl TerminalView {
                     );
                     let msg = e.to_string();
                     let _ = this.update(cx, |view, cx| {
-                        view.terminal.set_reconnect_state(ReconnectState::Failed(msg));
+                        view.terminal
+                            .set_reconnect_state(ReconnectState::Failed(msg));
                         view._reconnect_task = None;
                         cx.notify();
                     });
@@ -262,9 +263,9 @@ impl TerminalView {
                                             event = "ui.terminal.reconnect_channels_failed",
                                             error = %e,
                                         );
-                                        view.terminal.set_reconnect_state(
-                                            ReconnectState::Failed(e.to_string()),
-                                        );
+                                        view.terminal.set_reconnect_state(ReconnectState::Failed(
+                                            e.to_string(),
+                                        ));
                                         view._reconnect_task = None;
                                         cx.notify();
                                         return;
@@ -277,8 +278,8 @@ impl TerminalView {
                                 let exited = new_terminal.exited_flag().clone();
                                 let executor = cx.background_executor().clone();
 
-                                let event_task = cx.spawn(
-                                    async move |this2, cx2: &mut gpui::AsyncApp| {
+                                let event_task =
+                                    cx.spawn(async move |this2, cx2: &mut gpui::AsyncApp| {
                                         Terminal::run_batch_loop(
                                             term,
                                             pty_writer,
@@ -288,13 +289,11 @@ impl TerminalView {
                                             event_rx,
                                             executor,
                                             || {
-                                                let _ =
-                                                    this2.update(cx2, |_, cx| cx.notify());
+                                                let _ = this2.update(cx2, |_, cx| cx.notify());
                                             },
                                         )
                                         .await;
-                                    },
-                                );
+                                    });
 
                                 view.terminal = new_terminal;
                                 view._event_task = event_task;
@@ -311,9 +310,8 @@ impl TerminalView {
                                     session_id = session_id,
                                     error = %e,
                                 );
-                                view.terminal.set_reconnect_state(ReconnectState::Failed(
-                                    e.to_string(),
-                                ));
+                                view.terminal
+                                    .set_reconnect_state(ReconnectState::Failed(e.to_string()));
                                 view._reconnect_task = None;
                                 cx.notify();
                             }
@@ -333,7 +331,7 @@ impl TerminalView {
         let cmd = event.keystroke.modifiers.platform;
 
         // Intercept R key on dead daemon terminals to trigger reconnect.
-        if key == "r"
+        if key.eq_ignore_ascii_case("r")
             && !event.keystroke.modifiers.control
             && !cmd
             && self.terminal.has_exited()
@@ -458,7 +456,7 @@ impl Render for TerminalView {
             let (banner_bg, banner_text) = if is_daemon {
                 match &reconnect {
                     ReconnectState::Connecting => (
-                        theme::surface_1(),
+                        theme::surface(),
                         "Reconnecting to daemon session...".to_string(),
                     ),
                     ReconnectState::Failed(err) => (


### PR DESCRIPTION
## Summary

- Add `ReconnectState` enum (`Idle`, `Connecting`, `Failed`) and `daemon_session_id` field to `Terminal`
- Add `Reconnect` GPUI action on `TerminalView` triggered by R key when terminal has error
- Reconnect handler: spawns async task calling `connect_for_attach()`, builds new `Terminal::from_daemon()`, replaces terminal + event task atomically
- Update error banner to show reconnect status ("Press R to reconnect", "Reconnecting...", "Reconnect failed: {msg}")
- Edge cases: daemon gone (clear error), session destroyed (SessionNotFound), multiple R presses (debounced), local terminals (ignored)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `cargo build --all` passes
- [ ] Manual: open UI → create daemon session → kill daemon → press R → verify reconnection