### PR TITLE
feat(memory): project + fleet memory (engine-written room log + curated synthesis)

### DIFF
--- a/engine/src/kild/config.ts
+++ b/engine/src/kild/config.ts
@@ -34,6 +34,17 @@ export interface KildConfig {
    *  it's good at, cost). Appended to a delegating session's system prompt so the user
    *  and the orchestrator can steer which models fan-out agents run on. Order = preference. */
   models?: Record<string, string>;
+  /** Project memory behavior. The engine-written room log (`.kild/LOG.md`) is always on;
+   *  `synthesis` opts in to the LLM half: on room close, a session is spawned to distill
+   *  the transcript into `.kild/MEMORY.md`. Absent → no synthesis session is spawned. */
+  memory?: {
+    synthesis?: {
+      /** provider/model ref for the synthesis session (pick a strong reasoning model). */
+      model?: string;
+      /** Persona for the synthesis session (default: the general-purpose `default`). */
+      agent?: string;
+    };
+  };
 }
 
 export interface ResolvedPluginPaths {
@@ -102,4 +113,13 @@ export async function configuredModels(cwd: string): Promise<Record<string, stri
   const global = await readConfigFile(path.join(kildHome(), 'config.json'));
   const project = await readConfigFile(path.join(cwd, '.kild', 'config.json'));
   return { ...(global?.models ?? {}), ...(project?.models ?? {}) };
+}
+
+/** Merged memory-synthesis config (project wins over global); undefined = synthesis off. */
+export async function configuredMemorySynthesis(
+  cwd: string,
+): Promise<{ model?: string; agent?: string } | undefined> {
+  const global = await readConfigFile(path.join(kildHome(), 'config.json'));
+  const project = await readConfigFile(path.join(cwd, '.kild', 'config.json'));
+  return project?.memory?.synthesis ?? global?.memory?.synthesis;
 }

--- a/engine/src/kild/events.ts
+++ b/engine/src/kild/events.ts
@@ -7,6 +7,9 @@
  */
 export type UiEvent =
   | { kind: 'model'; provider: string; id: string }
+  /** The underlying pi session's durable identity — the terminal-resume handle
+   *  (`pi --session <file|id>`). Emitted once by the worker after session creation. */
+  | { kind: 'pi_session'; id: string; file?: string }
   | { kind: 'text'; delta: string }
   | { kind: 'tool_start'; id: string; name: string; args: string }
   | { kind: 'tool_end'; id: string; name: string; ok: boolean }

--- a/engine/src/kild/fleet/close-room-tool.ts
+++ b/engine/src/kild/fleet/close-room-tool.ts
@@ -9,14 +9,23 @@ export function createFleetCloseRoomTool(): ToolDefinition {
     label: 'Close Room',
     description:
       'Close a live kild room through the engine REST API. The engine stops every ' +
-      'participant and archives the transcript.',
+      'participant and archives the transcript. A room with open decisions refuses to ' +
+      'close: resolve each first (post "resolved[<key>]: <how>"), or pass force ONLY ' +
+      'when the human explicitly says to abandon the open decisions.',
     promptSnippet: 'close_room — close a live room by id',
     parameters: Type.Object({
       roomId: Type.String({ description: 'The live room id.' }),
+      force: Type.Optional(
+        Type.Boolean({
+          description:
+            'Close past open decisions. Only on an explicit human instruction — this buries ' +
+            'unresolved decisions.',
+        }),
+      ),
     }),
     async execute(_toolCallId, params) {
-      const { roomId } = params as { roomId: string };
-      const { message } = await closeRoom(roomId, process.env.KILD_SESSION_ID);
+      const { roomId, force } = params as { roomId: string; force?: boolean };
+      const { message } = await closeRoom(roomId, process.env.KILD_SESSION_ID, force);
       return {
         content: [{ type: 'text' as const, text: message }],
         details: null,

--- a/engine/src/kild/fleet/engine-client.ts
+++ b/engine/src/kild/fleet/engine-client.ts
@@ -55,11 +55,15 @@ export async function postRoom(
   });
 }
 
-export async function closeRoom(roomId: string, sessionId?: string): Promise<RoomActionResponse> {
+export async function closeRoom(
+  roomId: string,
+  sessionId?: string,
+  force?: boolean,
+): Promise<RoomActionResponse> {
   return engineFetch(`/api/rooms/${encodeURIComponent(roomId)}/close`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(sessionId ? { sessionId } : {}),
+    body: JSON.stringify({ ...(sessionId ? { sessionId } : {}), ...(force ? { force } : {}) }),
   });
 }
 

--- a/engine/src/kild/fleet/rooms-status-tool.ts
+++ b/engine/src/kild/fleet/rooms-status-tool.ts
@@ -9,8 +9,9 @@ export function createRoomsStatusTool(): ToolDefinition {
     name: 'rooms_status',
     label: 'Rooms Status',
     description:
-      'List live kild rooms as compact status summaries with participants and the last ' +
-      'one or two posts.',
+      'List live kild rooms as compact status summaries with participants, the last ' +
+      'one or two posts, and any openDecisions (unresolved keyed decisions that need an ' +
+      'operator call and block room close until resolved).',
     promptSnippet: 'rooms_status — summarize live rooms and their latest posts',
     parameters: Type.Object({}),
     async execute() {

--- a/engine/src/kild/fleet/rooms-status.test.ts
+++ b/engine/src/kild/fleet/rooms-status.test.ts
@@ -158,6 +158,30 @@ test('collisions: two workstreams that touch the same file each name the other',
   expect(byId.r3).not.toHaveProperty('collidesWith');
 });
 
+test('compact view surfaces only OPEN decisions and omits the field when none', () => {
+  const open = { key: 'auth', summary: 'token or session?', openedBy: 'worker', openedAt: 1 };
+  const resolved = {
+    key: 'api-shape',
+    summary: 'REST or RPC?',
+    openedBy: 'worker',
+    openedAt: 1,
+    resolvedBy: 'human',
+    resolvedAt: 2,
+  };
+  const [withDecisions, without] = compactLiveRooms([
+    {
+      id: 'room-1',
+      name: 'ops',
+      participants: [{ name: 'worker' }],
+      log: [],
+      decisions: [open, resolved],
+    },
+    { id: 'room-2', name: 'docs', participants: [{ name: 'worker' }], log: [] },
+  ]);
+  expect(withDecisions?.openDecisions).toEqual([open]);
+  expect(without).not.toHaveProperty('openDecisions');
+});
+
 test('compaction copies participant and post arrays without mutating the source room', () => {
   const rooms = [
     {

--- a/engine/src/kild/fleet/rooms-status.ts
+++ b/engine/src/kild/fleet/rooms-status.ts
@@ -1,3 +1,4 @@
+import { openDecisions, type RoomDecision } from '../room/room-decisions.ts';
 import type { LiveRoomStatus, ParticipantView, RoomMessage } from '../room/room-types.ts';
 import type { WorkstreamGitStatus } from '../worktree-status.ts';
 
@@ -41,6 +42,9 @@ export interface CompactRoomStatus {
   /** Other live workstreams that touch the same files — a merge collision waiting to
    *  happen. Empty/absent when this workstream collides with none. */
   collidesWith?: WorkstreamCollision[];
+  /** Unresolved keyed decisions — each needs an operator call before this room can close.
+   *  Absent when none are open (the normal case). */
+  openDecisions?: RoomDecision[];
 }
 
 /** Full changed-file list → a count for the compact view. `path` and the rest ride
@@ -70,16 +74,16 @@ export function computeCollisions(rooms: LiveRoomStatus[]): Map<string, Workstre
 
 export function compactLiveRooms(liveRooms: LiveRoomStatus[]): CompactRoomStatus[] {
   const collisions = computeCollisions(liveRooms);
-  return liveRooms.map((room) => ({
-    id: room.id,
-    name: room.name,
-    participants: room.participants.map((participant) => ({
-      name: participant.name,
-      agent: participant.agent,
-      model: participant.model,
-    })),
-    posts: room.log.slice(-2),
-    ...(room.git ? { git: toCompactGit(room.git) } : {}),
-    ...(collisions.has(room.id) ? { collidesWith: collisions.get(room.id) } : {}),
-  }));
+  return liveRooms.map((room) => {
+    const open = openDecisions(room);
+    return {
+      id: room.id,
+      name: room.name,
+      participants: room.participants.map((participant) => ({ ...participant })),
+      posts: room.log.slice(-2),
+      ...(room.git ? { git: toCompactGit(room.git) } : {}),
+      ...(collisions.has(room.id) ? { collidesWith: collisions.get(room.id) } : {}),
+      ...(open.length > 0 ? { openDecisions: open } : {}),
+    };
+  });
 }

--- a/engine/src/kild/mechanism-prompt.ts
+++ b/engine/src/kild/mechanism-prompt.ts
@@ -53,6 +53,13 @@ posting, kild nudges IT to report — you don't have to chase it, so just contin
 post arrives. Report your own results to whoever delegated to you (or to @human if the
 human asked) — not by default to @human.
 
+When a blocker in a room needs a call from the human or the driver, mark it as a keyed
+decision so it cannot be lost: put \`needs-decision[<key>]: <one-line question>\` on its own
+line in your post (key = a short slug like \`api-shape\`). It stays open — visible in room
+status and blocking room close — until someone explicitly posts \`resolved[<key>]: <how>\`.
+When you receive a call on a decision you raised, act on it and post the \`resolved[<key>]\`
+line with the outcome. Never mark a decision resolved that wasn't actually decided.
+
 When your work is done, post your final report and then STOP. Do NOT close the room —
 closing kills every agent's context and cannot be undone. A finished room idles: agents
 stay alive and keep their full context, so the human (or you) can follow up later just by

--- a/engine/src/kild/memory.test.ts
+++ b/engine/src/kild/memory.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  appendRoomLog,
+  fleetMemorySection,
+  formatRoomLogEntry,
+  projectMemorySection,
+  synthesisPrompt,
+} from './memory.ts';
+import type { Room } from './room/room-types.ts';
+
+let tmp: string;
+let prevHome: string | undefined;
+
+beforeAll(() => {
+  prevHome = process.env.KILD_HOME;
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kild-memory-'));
+  process.env.KILD_HOME = path.join(tmp, 'home');
+});
+
+afterAll(() => {
+  if (prevHome === undefined) delete process.env.KILD_HOME;
+  else process.env.KILD_HOME = prevHome;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function room(cwd: string, overrides: Partial<Room> = {}): Room {
+  return {
+    id: 'room-1',
+    name: 'fix-auth',
+    cwd,
+    participants: [
+      {
+        name: 'worker',
+        sessionId: 's-1',
+        agent: 'worker',
+        model: 'openai-codex/gpt-5.6-sol',
+        piSessionId: 'aaaa-bbbb',
+        piSessionFile: '/sessions/aaaa-bbbb.jsonl',
+      },
+    ],
+    log: [
+      {
+        id: 'm0',
+        roomId: 'room-1',
+        from: 'human',
+        to: ['worker'],
+        text: 'Fix the auth bug',
+        ts: 1,
+      },
+      { id: 'm1', roomId: 'room-1', from: 'human', to: [], text: 'joined', ts: 2, system: true },
+      {
+        id: 'm2',
+        roomId: 'room-1',
+        from: 'worker',
+        to: ['human'],
+        text: 'Done: commit abc123, tests green',
+        ts: 3,
+      },
+    ],
+    state: 'closed',
+    worktree: 'fix-auth',
+    base: 'main',
+    ...overrides,
+  };
+}
+
+test('the log entry carries goal, outcome, decisions, resume handles, worktree — pure facts', () => {
+  const entry = formatRoomLogEntry(
+    room('/p', {
+      decisions: [
+        {
+          key: 'api-shape',
+          summary: 'REST or RPC?',
+          openedBy: 'worker',
+          openedAt: 1,
+          resolvedBy: 'human',
+          resolvedAt: 2,
+          note: 'REST',
+        },
+        { key: 'auth', summary: 'token TTL?', openedBy: 'worker', openedAt: 3 },
+      ],
+    }),
+    new Date('2026-07-24T12:00:00Z'),
+  );
+  expect(entry).toContain('## 2026-07-24 — fix-auth (room-1)');
+  expect(entry).toContain('- goal: Fix the auth bug');
+  expect(entry).toContain('- outcome: Done: commit abc123, tests green');
+  expect(entry).toContain('→ resolved by @human: REST');
+  expect(entry).toContain('decision UNRESOLVED at close: auth');
+  expect(entry).toContain(
+    '- agent @worker (worker, openai-codex/gpt-5.6-sol) — pi --session /sessions/aaaa-bbbb.jsonl',
+  );
+  expect(entry).toContain('- worktree: kild/fix-auth (base main)');
+});
+
+test('appendRoomLog creates .kild with a memory .gitignore and appends in order', () => {
+  const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
+  appendRoomLog(room(project), new Date('2026-07-24T12:00:00Z'));
+  appendRoomLog(room(project, { id: 'room-2', name: 'second' }), new Date('2026-07-25T12:00:00Z'));
+
+  const log = fs.readFileSync(path.join(project, '.kild', 'LOG.md'), 'utf8');
+  expect(log.indexOf('fix-auth')).toBeLessThan(log.indexOf('second'));
+
+  const gitignore = fs.readFileSync(path.join(project, '.kild', '.gitignore'), 'utf8');
+  for (const name of ['MEMORY.md', 'LOG.md', 'direction.md', '.memory-state.json']) {
+    expect(gitignore).toContain(name);
+  }
+});
+
+test('an existing .kild/.gitignore is never clobbered', () => {
+  const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
+  fs.mkdirSync(path.join(project, '.kild'), { recursive: true });
+  fs.writeFileSync(path.join(project, '.kild', '.gitignore'), '# user-managed\n');
+  appendRoomLog(room(project));
+  expect(fs.readFileSync(path.join(project, '.kild', '.gitignore'), 'utf8')).toBe(
+    '# user-managed\n',
+  );
+});
+
+test('projectMemorySection composes MEMORY.md + direction.md and is empty when absent', () => {
+  const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
+  expect(projectMemorySection(project)).toBe('');
+  fs.mkdirSync(path.join(project, '.kild'), { recursive: true });
+  fs.writeFileSync(path.join(project, '.kild', 'MEMORY.md'), 'Auth uses tokens.');
+  fs.writeFileSync(path.join(project, '.kild', 'direction.md'), 'Ship v2 by fall.');
+  const section = projectMemorySection(project);
+  expect(section).toContain('<project-memory>');
+  expect(section).toContain('Auth uses tokens.');
+  expect(section).toContain('Ship v2 by fall.');
+});
+
+test('fleetMemorySection reads $KILD_HOME/MAIN_MEMORY.md and is empty when absent', () => {
+  expect(fleetMemorySection()).toBe('');
+  fs.mkdirSync(process.env.KILD_HOME as string, { recursive: true });
+  fs.writeFileSync(
+    path.join(process.env.KILD_HOME as string, 'MAIN_MEMORY.md'),
+    '- projA — the API',
+  );
+  expect(fleetMemorySection()).toContain('projA — the API');
+});
+
+test('the synthesis charter names the transcript, the memory file, and the constraints', () => {
+  const prompt = synthesisPrompt(room('/p'), '/home/rooms/room-1.json');
+  expect(prompt).toContain('[kild memory synthesis]');
+  expect(prompt).toContain('/home/rooms/room-1.json');
+  expect(prompt).toContain('.kild/MEMORY.md');
+  expect(prompt).toContain('READ-ONLY');
+});

--- a/engine/src/kild/memory.ts
+++ b/engine/src/kild/memory.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { kildHome } from './config.ts';
+import type { RoomDecision } from './room/room-decisions.ts';
+import { finalNonSystemPost } from './room/room-events.ts';
+import type { Room } from './room/room-types.ts';
+
+/**
+ * Project memory — the filesystem half of "kild remembers".
+ *
+ * Two layers with different owners, deliberately split:
+ *
+ * - `.kild/LOG.md` — append-only, ENGINE-written: one entry per closed room, built
+ *   entirely from structured state the engine already holds (goal, outcome, decisions,
+ *   agents + their pi resume handles, worktree). Free, instant, never hallucinates.
+ * - `.kild/MEMORY.md` — lean CURATED memory, written by an optional synthesis session
+ *   (config `memory.synthesis`) that reads the transcript and distills judgment-work:
+ *   learnings, direction, the why behind decisions. `.kild/direction.md` is human-owned
+ *   product direction; the engine only ever reads it.
+ *
+ * Fleet-level memory is `$KILD_HOME/MAIN_MEMORY.md` — the operator's cross-project
+ * index. All memory files are personal for now (gitignored via `.kild/.gitignore`),
+ * which also means worktree checkouts don't carry them: memory is always read from and
+ * written to the project's MAIN checkout (`room.cwd`), never a worktree.
+ */
+
+const MEMORY_GITIGNORE = ['MEMORY.md', 'LOG.md', 'direction.md', '.memory-state.json'];
+/** Per-file cap for injected memory sections — memory rides every first turn, so it must
+ *  stay lean; the synthesis charter enforces leanness at write time, this at read time. */
+const SECTION_MAX_CHARS = 6000;
+
+function truncate(text: string, max: number): string {
+  const flat = text.trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+function oneLine(text: string, max: number): string {
+  return truncate(text.replace(/\s+/g, ' '), max);
+}
+
+/** Ensure `.kild/` exists with a `.gitignore` covering the personal memory files.
+ *  Never clobbers an existing `.gitignore` (the committed-vs-personal call is the
+ *  user's to change there). */
+function ensureMemoryDir(projectCwd: string): string {
+  const dir = path.join(projectCwd, '.kild');
+  fs.mkdirSync(dir, { recursive: true });
+  const gitignore = path.join(dir, '.gitignore');
+  if (!fs.existsSync(gitignore)) {
+    fs.writeFileSync(gitignore, `${MEMORY_GITIGNORE.join('\n')}\n`);
+  }
+  return dir;
+}
+
+function formatDecision(decision: RoomDecision): string {
+  const opened = `${decision.key} (${decision.summary}, raised by @${decision.openedBy})`;
+  if (decision.resolvedAt === undefined) return `- decision UNRESOLVED at close: ${opened}`;
+  const note = decision.note ? `: ${decision.note}` : '';
+  return `- decision ${opened} → resolved by @${decision.resolvedBy}${note}`;
+}
+
+/** One room's log entry, built purely from engine-held state. */
+export function formatRoomLogEntry(room: Room, closedAt: Date): string {
+  const lines: string[] = [];
+  lines.push(`## ${closedAt.toISOString().slice(0, 10)} — ${room.name} (${room.id})`);
+  const kickoff = room.log.find((message) => !message.system);
+  if (kickoff) lines.push(`- goal: ${oneLine(kickoff.text, 240)}`);
+  lines.push(`- outcome: ${oneLine(finalNonSystemPost(room), 400)}`);
+  for (const decision of room.decisions ?? []) lines.push(formatDecision(decision));
+  for (const participant of room.participants) {
+    const persona = participant.agent ?? 'default';
+    const model = participant.model ? `, ${participant.model}` : '';
+    const resume = participant.piSessionFile ?? participant.piSessionId;
+    const handle = resume ? ` — pi --session ${resume}` : '';
+    lines.push(`- agent @${participant.name} (${persona}${model})${handle}`);
+  }
+  if (room.worktree) lines.push(`- worktree: kild/${room.worktree} (base ${room.base ?? '?'})`);
+  return `${lines.join('\n')}\n\n`;
+}
+
+/** Append the room's entry to the project's `.kild/LOG.md`; returns the log path. */
+export function appendRoomLog(room: Room, closedAt: Date = new Date()): string {
+  const dir = ensureMemoryDir(room.cwd);
+  const logPath = path.join(dir, 'LOG.md');
+  fs.appendFileSync(logPath, formatRoomLogEntry(room, closedAt));
+  return logPath;
+}
+
+function readCapped(file: string): string {
+  try {
+    const content = fs.readFileSync(file, 'utf8').trim();
+    return content ? truncate(content, SECTION_MAX_CHARS) : '';
+  } catch {
+    return '';
+  }
+}
+
+/** The project-memory prompt section (curated memory + human-owned direction), read from
+ *  the project's MAIN checkout. Empty string when neither file has content. */
+export function projectMemorySection(projectCwd: string): string {
+  const dir = path.join(projectCwd, '.kild');
+  const memory = readCapped(path.join(dir, 'MEMORY.md'));
+  const direction = readCapped(path.join(dir, 'direction.md'));
+  if (!memory && !direction) return '';
+  const parts = [
+    memory ? `Curated project memory (.kild/MEMORY.md):\n${memory}` : '',
+    direction ? `Product direction (.kild/direction.md, human-owned):\n${direction}` : '',
+  ].filter(Boolean);
+  return `<project-memory>\n${parts.join('\n\n')}\n</project-memory>`;
+}
+
+/** The fleet-memory prompt section (`$KILD_HOME/MAIN_MEMORY.md`) for operator/driver
+ *  sessions that steer many projects. Empty string when absent. */
+export function fleetMemorySection(): string {
+  const memory = readCapped(path.join(kildHome(), 'MAIN_MEMORY.md'));
+  if (!memory) return '';
+  return `<fleet-memory>\nYour cross-project fleet memory ($KILD_HOME/MAIN_MEMORY.md):\n${memory}\n</fleet-memory>`;
+}
+
+/** The synthesis session's task charter — mechanism only (what inputs, what file, what
+ *  constraints); its judgment/voice comes from the configured persona, not from here. */
+export function synthesisPrompt(room: Room, transcriptPath: string): string {
+  return (
+    `[kild memory synthesis] Room '${room.name}' just closed in this project.\n\n` +
+    `Inputs:\n` +
+    `- Room transcript (JSON): ${transcriptPath}\n` +
+    `- Engine-written room log: .kild/LOG.md — this room's factual entry is already ` +
+    `appended; do not duplicate its facts.\n` +
+    `- Current curated memory: .kild/MEMORY.md (may not exist yet)\n` +
+    `- Product direction (human-owned, READ-ONLY): .kild/direction.md (may not exist)\n\n` +
+    `Task: read the transcript, then update .kild/MEMORY.md so it stays a LEAN curated ` +
+    `memory of this project: key decisions and who made them (including resolved ` +
+    `needs-decision[...] calls), important human calls, durable learnings, and current ` +
+    `direction. Compress and rewrite — do not append-and-grow; keep it under ~120 lines ` +
+    `of markdown prose (no schemas, no tables of raw facts the log already holds). ` +
+    `Do not modify any other file, do not touch code, do not commit.`
+  );
+}
+
+/** Path of the persisted room transcript the registry writes (input for synthesis). */
+export function roomTranscriptPath(roomId: string): string {
+  return path.join(kildHome(), 'rooms', `${roomId}.json`);
+}

--- a/engine/src/kild/room/room-decisions.test.ts
+++ b/engine/src/kild/room/room-decisions.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from 'bun:test';
+
+import {
+  applyDecisionMarkers,
+  formatOpenDecisions,
+  openDecisions,
+  type RoomDecision,
+} from './room-decisions.ts';
+
+function post(from: string, text: string, ts = 1000) {
+  return { from, text, ts, system: false };
+}
+
+test('needs-decision opens a keyed decision attributed to the poster', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  const changed = applyDecisionMarkers(
+    room,
+    post(
+      'worker',
+      'Blocked on a call.\nneeds-decision[api-shape]: REST or RPC for the new endpoint?',
+    ),
+  );
+  expect(changed).toBe(true);
+  expect(openDecisions(room)).toEqual([
+    {
+      key: 'api-shape',
+      summary: 'REST or RPC for the new endpoint?',
+      openedBy: 'worker',
+      openedAt: 1000,
+    },
+  ]);
+});
+
+test('resolved closes only the named open decision and records the resolver', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  applyDecisionMarkers(room, post('worker', 'needs-decision[api-shape]: REST or RPC?'));
+  applyDecisionMarkers(room, post('worker', 'needs-decision[auth]: token or session?'));
+  const changed = applyDecisionMarkers(
+    room,
+    post('human', 'resolved[api-shape]: REST, matches the rest of the API', 2000),
+  );
+  expect(changed).toBe(true);
+  expect(openDecisions(room).map((d) => d.key)).toEqual(['auth']);
+  const resolved = room.decisions?.find((d) => d.key === 'api-shape');
+  expect(resolved).toMatchObject({
+    resolvedBy: 'human',
+    resolvedAt: 2000,
+    note: 'REST, matches the rest of the API',
+  });
+});
+
+test('a later done-style post never closes an open decision (the invariant)', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  applyDecisionMarkers(room, post('worker', 'needs-decision[api-shape]: REST or RPC?'));
+  const changed = applyDecisionMarkers(
+    room,
+    post('worker', 'Done — implemented, tests green, decision handled.'),
+  );
+  expect(changed).toBe(false);
+  expect(openDecisions(room)).toHaveLength(1);
+});
+
+test('resolving an unknown key is a silent no-op', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  expect(applyDecisionMarkers(room, post('human', 'resolved[nothing-open]: n/a'))).toBe(false);
+  expect(room.decisions ?? []).toHaveLength(0);
+});
+
+test('re-opening an open key refreshes its summary instead of duplicating', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  applyDecisionMarkers(room, post('worker', 'needs-decision[auth]: token or session?'));
+  applyDecisionMarkers(
+    room,
+    post('worker', 'needs-decision[auth]: token, session, or mTLS?', 2000),
+  );
+  expect(room.decisions).toHaveLength(1);
+  expect(openDecisions(room)[0]).toMatchObject({
+    summary: 'token, session, or mTLS?',
+    openedAt: 1000, // the original raise, not the refresh
+  });
+});
+
+test('a resolved key can be raised again as a fresh decision', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  applyDecisionMarkers(room, post('worker', 'needs-decision[auth]: token or session?'));
+  applyDecisionMarkers(room, post('human', 'resolved[auth]: token', 2000));
+  applyDecisionMarkers(room, post('worker', 'needs-decision[auth]: rotate how often?', 3000));
+  expect(room.decisions).toHaveLength(2);
+  expect(openDecisions(room)).toEqual([
+    { key: 'auth', summary: 'rotate how often?', openedBy: 'worker', openedAt: 3000 },
+  ]);
+});
+
+test('resolved with no note leaves note unset', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  applyDecisionMarkers(room, post('worker', 'needs-decision[auth]: token or session?'));
+  applyDecisionMarkers(room, post('human', 'resolved[auth]', 2000));
+  expect(room.decisions?.[0]?.note).toBeUndefined();
+  expect(openDecisions(room)).toHaveLength(0);
+});
+
+test('malformed markers are ignored: bad key charset, missing summary, mid-line mention', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  const text = [
+    'needs-decision[bad key]: spaces in the key',
+    'needs-decision[api-shape]:', // no summary
+    'see the earlier needs-decision[api-shape]: marker for context', // not line-anchored
+  ].join('\n');
+  expect(applyDecisionMarkers(room, post('worker', text))).toBe(false);
+  expect(room.decisions ?? []).toHaveLength(0);
+});
+
+test('system notices never touch the ledger', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  const changed = applyDecisionMarkers(room, {
+    from: 'human',
+    text: 'needs-decision[x]: from a notice',
+    ts: 1000,
+    system: true,
+  });
+  expect(changed).toBe(false);
+  expect(room.decisions ?? []).toHaveLength(0);
+});
+
+test('formatOpenDecisions renders a compact attributed list', () => {
+  const room: { decisions?: RoomDecision[] } = {};
+  applyDecisionMarkers(room, post('worker', 'needs-decision[auth]: token or session?'));
+  expect(formatOpenDecisions(room)).toBe('auth (token or session?, raised by @worker)');
+  expect(formatOpenDecisions({})).toBe('');
+});

--- a/engine/src/kild/room/room-decisions.ts
+++ b/engine/src/kild/room/room-decisions.ts
@@ -1,0 +1,88 @@
+import type { Room, RoomMessage } from './room-types.ts';
+
+/**
+ * Keyed decisions — the durable "this needs a call" ledger on a room.
+ *
+ * The invariant (borrowed from firstmate's status fold): a raised decision can never
+ * close *implicitly*. A `needs-decision[key]:` line in any ordinary post opens a keyed
+ * decision on the room; only an explicit `resolved[key]` line closes it. A later "done"
+ * post, an idle room, or a dropped gate digest cannot mask it — `rooms_status` keeps
+ * surfacing it and `close_room` refuses while any decision is open (operator `force`
+ * is the escape hatch).
+ *
+ * This module is the ONE place that decides what counts as a decision marker — the
+ * same pattern as `parseMentions` for addressing. Grammar, line-anchored inside a
+ * post's text (a post may carry prose around the marker lines):
+ *
+ *   needs-decision[<key>]: <summary>   — opens (or refreshes) decision <key>
+ *   resolved[<key>]                    — closes it; optional `: <note>`
+ *
+ * Keys are `[A-Za-z0-9._-]+`. Who may resolve is deliberately unrestricted: resolution
+ * is attributed and on the log, so it is loud — identity *enforcement* is the
+ * engine-derived-actors slice's job, not this one's.
+ */
+export interface RoomDecision {
+  key: string;
+  summary: string;
+  /** Participant name or HUMAN — whoever posted the opening marker. */
+  openedBy: string;
+  /** Epoch millis of the opening post. */
+  openedAt: number;
+  resolvedBy?: string;
+  resolvedAt?: number;
+  note?: string;
+}
+
+const OPEN_RE = /^\s*needs-decision\[([A-Za-z0-9._-]+)\]:\s*(\S.*)$/;
+const RESOLVE_RE = /^\s*resolved\[([A-Za-z0-9._-]+)\](?::\s*(.*\S))?\s*$/;
+
+export function openDecisions(room: Pick<Room, 'decisions'>): RoomDecision[] {
+  return (room.decisions ?? []).filter((decision) => decision.resolvedAt === undefined);
+}
+
+/** One-line human-readable list of a room's open decisions (empty string when none). */
+export function formatOpenDecisions(room: Pick<Room, 'decisions'>): string {
+  return openDecisions(room)
+    .map((decision) => `${decision.key} (${decision.summary}, raised by @${decision.openedBy})`)
+    .join('; ');
+}
+
+/**
+ * Fold one post's decision markers into the room's ledger (mutates `room.decisions`).
+ * Re-opening a key that is already open refreshes its summary; resolving a key with no
+ * open decision is a silent no-op (the marker still sits attributed on the log).
+ * Returns whether the ledger changed, so the caller knows to re-persist.
+ */
+export function applyDecisionMarkers(
+  room: Pick<Room, 'decisions'>,
+  message: Pick<RoomMessage, 'from' | 'text' | 'ts' | 'system'>,
+): boolean {
+  if (message.system) return false;
+  let changed = false;
+  for (const line of message.text.split('\n')) {
+    const open = OPEN_RE.exec(line);
+    if (open) {
+      const [, key, summary] = open as unknown as [string, string, string];
+      const existing = openDecisions(room).find((decision) => decision.key === key);
+      if (existing) {
+        existing.summary = summary;
+      } else {
+        room.decisions = room.decisions ?? [];
+        room.decisions.push({ key, summary, openedBy: message.from, openedAt: message.ts });
+      }
+      changed = true;
+      continue;
+    }
+    const resolve = RESOLVE_RE.exec(line);
+    if (resolve) {
+      const [, key, note] = resolve as unknown as [string, string, string | undefined];
+      const existing = openDecisions(room).find((decision) => decision.key === key);
+      if (!existing) continue;
+      existing.resolvedBy = message.from;
+      existing.resolvedAt = message.ts;
+      if (note) existing.note = note;
+      changed = true;
+    }
+  }
+  return changed;
+}

--- a/engine/src/kild/room/room-manager.test.ts
+++ b/engine/src/kild/room/room-manager.test.ts
@@ -70,7 +70,7 @@ async function openRoom(
   roomId: string = 'room-1',
   openedBy?: string,
 ) {
-  return manager.open(roomId, { name: 'demo', cwd: '/tmp', participants, openedBy });
+  return manager.open(roomId, { name: 'demo', cwd: tmp, participants, openedBy });
 }
 
 test('rejects a duplicate room id and preserves the existing room', async () => {
@@ -473,4 +473,163 @@ test('a delivered turn re-arms the failsafe (idle-without-post next turn nudges 
   emitSession(WORKER, { kind: 'agent_end' }); // idle without post again → nudge 2
 
   expect(prompted.filter(isNudge)).toHaveLength(2);
+});
+
+// ── keyed decisions: no decision leaves the system silently ──────────────────────────
+
+test('a needs-decision post opens a keyed decision and blocks close until force', async () => {
+  const { manager, callbacks } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await callbacks.get('s-1')?.onMessage?.({
+    kind: 'message_out',
+    text: 'Two options here.\nneeds-decision[api-shape]: REST or RPC?',
+    to: ['human'],
+  });
+
+  const refused = await manager.close('room-1');
+  expect(refused).toMatchObject({ ok: false, code: 'rejected' });
+  expect((refused as { message: string }).message).toContain('api-shape');
+  expect((refused as { message: string }).message).toContain('force');
+
+  expect(await manager.close('room-1', { force: true })).toEqual({
+    ok: true,
+    value: { message: "Room 'demo' closed." },
+  });
+});
+
+test('a resolved post closes the decision and unblocks an ordinary close', async () => {
+  const { manager, callbacks } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await callbacks.get('s-1')?.onMessage?.({
+    kind: 'message_out',
+    text: 'needs-decision[api-shape]: REST or RPC?',
+    to: ['human'],
+  });
+  await manager.postFromHuman('room-1', 'resolved[api-shape]: REST — matches the existing API');
+
+  expect(await manager.close('room-1')).toMatchObject({ ok: true });
+});
+
+test('a later done post never masks an open decision (the fold invariant)', async () => {
+  const { manager, callbacks } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await callbacks.get('s-1')?.onMessage?.({
+    kind: 'message_out',
+    text: 'needs-decision[auth]: token or session?',
+    to: ['human'],
+  });
+  await callbacks.get('s-1')?.onMessage?.({
+    kind: 'message_out',
+    text: 'done: shipped it, all handled',
+    to: ['human'],
+  });
+  expect(await manager.close('room-1')).toMatchObject({ ok: false, code: 'rejected' });
+});
+
+test('the lead cannot close (or force) past an open decision — operator only', async () => {
+  const { manager, callbacks } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await callbacks.get('s-1')?.onMessage?.({
+    kind: 'message_out',
+    text: 'needs-decision[auth]: token or session?',
+    to: ['human'],
+  });
+  const result = await callbacks.get('s-1')?.onCloseRoom?.({ kind: 'close_room' });
+  expect(result).toMatchObject({ ok: false, code: 'rejected' });
+  expect((result as { message: string }).message).toContain('operator');
+  expect(manager.liveRooms()).toHaveLength(1); // the room survived
+});
+
+test('decisions ride the live view and the archived snapshot', async () => {
+  const { manager, callbacks } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await callbacks.get('s-1')?.onMessage?.({
+    kind: 'message_out',
+    text: 'needs-decision[auth]: token or session?',
+    to: ['human'],
+  });
+
+  expect(manager.liveRooms()[0]?.decisions).toMatchObject([
+    { key: 'auth', summary: 'token or session?', openedBy: 'worker' },
+  ]);
+
+  await manager.close('room-1', { force: true });
+  expect(manager.archived()[0]?.decisions).toMatchObject([{ key: 'auth', openedBy: 'worker' }]);
+});
+
+// ── pi session identity: the terminal-resume handle ──────────────────────────────────
+
+test('a pi_session event lands on the participant and rides the live view', async () => {
+  const { manager, emitSession } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await manager.postFromHuman('room-1', 'kick off'); // give the room history to persist
+  emitSession('s-1', {
+    kind: 'pi_session',
+    id: 'aaaa-bbbb',
+    file: '/home/u/.pi/agent/sessions/x/aaaa-bbbb.jsonl',
+  });
+
+  expect(manager.liveRooms()[0]?.participants[0]).toMatchObject({
+    name: 'worker',
+    piSessionId: 'aaaa-bbbb',
+    piSessionFile: '/home/u/.pi/agent/sessions/x/aaaa-bbbb.jsonl',
+  });
+});
+
+test('pi session handles survive into the archived snapshot', async () => {
+  const { manager, emitSession } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await manager.postFromHuman('room-1', 'kick off');
+  emitSession('s-1', { kind: 'pi_session', id: 'aaaa-bbbb', file: '/tmp/s.jsonl' });
+  await manager.close('room-1');
+
+  expect(manager.archived()[0]?.participants[0]).toMatchObject({
+    piSessionId: 'aaaa-bbbb',
+    piSessionFile: '/tmp/s.jsonl',
+  });
+});
+
+// ── memory hook: engine-written log on close, optional synthesis spawn ────────────────
+
+test('closing a room with history appends its engine-written entry to .kild/LOG.md', async () => {
+  const { manager } = fixture();
+  const project = fs.mkdtempSync(path.join(tmp, 'memproj-'));
+  await manager.open('room-1', { name: 'demo', cwd: project, participants: [{ name: 'worker' }] });
+  await manager.postFromHuman('room-1', 'ship the fix');
+  await manager.close('room-1');
+
+  const log = fs.readFileSync(path.join(project, '.kild', 'LOG.md'), 'utf8');
+  expect(log).toContain('demo (room-1)');
+  expect(log).toContain('- goal: ship the fix');
+});
+
+test('memory.synthesis config spawns a synthesis session in the MAIN checkout after close', async () => {
+  const { manager, spawned, prompted } = fixture();
+  const project = fs.mkdtempSync(path.join(tmp, 'memproj-'));
+  fs.mkdirSync(path.join(project, '.kild'), { recursive: true });
+  fs.writeFileSync(
+    path.join(project, '.kild', 'config.json'),
+    JSON.stringify({
+      memory: { synthesis: { model: 'openai-codex/gpt-5.6-sol', agent: 'default' } },
+    }),
+  );
+  await manager.open('room-1', { name: 'demo', cwd: project, participants: [{ name: 'worker' }] });
+  await manager.postFromHuman('room-1', 'ship the fix');
+  const before = spawned.length;
+  await manager.close('room-1');
+
+  expect(spawned.length).toBe(before + 1);
+  const synthesisPromptDelivered = prompted.find((p) => p.text.includes('[kild memory synthesis]'));
+  expect(synthesisPromptDelivered?.from).toBe('kild');
+  expect(synthesisPromptDelivered?.text).toContain('.kild/MEMORY.md');
+});
+
+test('without memory.synthesis config, close spawns nothing extra', async () => {
+  const { manager, spawned } = fixture();
+  const project = fs.mkdtempSync(path.join(tmp, 'memproj-'));
+  await manager.open('room-1', { name: 'demo', cwd: project, participants: [{ name: 'worker' }] });
+  await manager.postFromHuman('room-1', 'ship the fix');
+  const before = spawned.length;
+  await manager.close('room-1');
+  expect(spawned.length).toBe(before);
 });

--- a/engine/src/kild/room/room-manager.ts
+++ b/engine/src/kild/room/room-manager.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
 import { listAgents } from '../agents.ts';
+import { configuredMemorySynthesis } from '../config.ts';
+import { appendRoomLog, roomTranscriptPath, synthesisPrompt } from '../memory.ts';
 import { type SessionCallbacks, type SpawnRequest, sessionManager } from '../sessions.ts';
 import { resolveBaseBranch, worktreePath } from '../worktree.ts';
 import { workstreamGitStatus } from '../worktree-status.ts';
+import { applyDecisionMarkers, formatOpenDecisions, openDecisions } from './room-decisions.ts';
 import {
   finalNonSystemPost,
   formatOperatorNotification,
@@ -31,6 +34,7 @@ import {
   type OpenRoomSpec,
   type OpenRoomSuccess,
   type ParticipantSpec,
+  participantView,
   type Room,
   type RoomActionSuccess,
   type RoomMessage,
@@ -121,9 +125,22 @@ export class RoomManager {
       if (located) {
         // Capture the provider-resolved model so observers see what each agent actually
         // ran on (not just the requested ref — which may have been a default/alias).
-        const event = msg.event as { kind?: string; provider?: string; id?: string };
+        const event = msg.event as {
+          kind?: string;
+          provider?: string;
+          id?: string;
+          file?: string;
+        };
         if (event.kind === 'model' && event.provider && event.id) {
           located.participant.model = `${event.provider}/${event.id}`;
+        }
+        // The pi session identity is the participant's durable terminal-resume handle;
+        // persist it so archived rooms keep it too (there may be no later post to piggyback
+        // the snapshot on).
+        if (event.kind === 'pi_session' && event.id) {
+          located.participant.piSessionId = event.id;
+          located.participant.piSessionFile = event.file;
+          this.registry.persistNow(located.room.id);
         }
         // Failsafe on a finished turn: if a delegate went idle WITHOUT posting, its inviter
         // is blind (an explicit post would have woken the inviter via routing). Nudge the
@@ -241,13 +258,10 @@ export class RoomManager {
         id: room.id,
         name: room.name,
         worktree: room.worktree,
-        participants: room.participants.map((p) => ({
-          name: p.name,
-          agent: p.agent,
-          model: p.model,
-        })),
+        participants: room.participants.map(participantView),
         state: room.state,
         log: room.log,
+        decisions: room.decisions,
         git: await workstreamGitStatus(
           room.worktree ? worktreePath(room.worktree) : room.cwd,
           room.base,
@@ -287,12 +301,26 @@ export class RoomManager {
 
   /** Stop every participant session — the human kill switch / room teardown. A room
    *  with history moves straight into the archive and is pushed to clients, so it stays
-   *  visible as a read-only transcript without an engine restart. */
-  async close(roomId: string): Promise<CommandResult<RoomActionSuccess>> {
+   *  visible as a read-only transcript without an engine restart.
+   *
+   *  Open decisions block the close (the fold's whole guarantee: a raised decision
+   *  cannot leave the system silently). `force` is the operator's escape hatch — it is
+   *  never offered to the in-room lead path ({@link handleCloseRoom}). */
+  async close(
+    roomId: string,
+    opts: { force?: boolean } = {},
+  ): Promise<CommandResult<RoomActionSuccess>> {
     const room = this.registry.get(roomId);
     if (!room) return fail('not_found', `no such room: ${roomId}`);
     const allowed = ensureRoomCanCloseFromOperator(room);
     if (!allowed.ok) return allowed;
+    if (!opts.force && openDecisions(room).length > 0) {
+      return fail(
+        'rejected',
+        `room '${room.name}' has open decisions: ${formatOpenDecisions(room)}. ` +
+          `Resolve each (post 'resolved[<key>]: <how>') or close with force.`,
+      );
+    }
     for (const participant of room.participants) this.sessions.stop(participant.sessionId);
     const transitioned = transitionRoomState(room, 'closed');
     if (!transitioned.ok) return transitioned;
@@ -303,6 +331,7 @@ export class RoomManager {
     });
     if (archived) this.broadcast({ archivedRoom: archived });
     this.broadcast({ rooms: this.registry.summaries() });
+    if (archived) await this.recordMemory(room);
     return ok({ message: `Room '${room.name}' closed.` });
   }
 
@@ -327,6 +356,37 @@ export class RoomManager {
     });
     this.broadcast({ rooms: this.registry.summaries() });
     return ok({ message: `Room '${room.name}' halted.` });
+  }
+
+  /** Post-close memory hook: append the engine-written log entry (always), then spawn
+   *  the optional synthesis session (config `memory.synthesis`) to distill the transcript
+   *  into `.kild/MEMORY.md`. Memory must never break a close — failures are logged loud
+   *  and swallowed here, at the one boundary where that is the right call. */
+  private async recordMemory(room: Room): Promise<void> {
+    try {
+      appendRoomLog(room);
+    } catch (err) {
+      console.error(
+        `kild: room log append failed for '${room.name}': ${err instanceof Error ? err.message : err}`,
+      );
+      return; // no log entry → don't synthesize against a missing input
+    }
+    try {
+      const synthesis = await configuredMemorySynthesis(room.cwd);
+      if (!synthesis) return;
+      const id = this.createId();
+      this.sessions.spawn(id, {
+        model: synthesis.model,
+        cwd: room.cwd, // the MAIN checkout — memory files are gitignored, so worktrees never see them
+        agent: synthesis.agent ?? 'default',
+        projectName: `memory:${room.name}`,
+      });
+      this.sessions.prompt(id, synthesisPrompt(room, roomTranscriptPath(room.id)), 'kild');
+    } catch (err) {
+      console.error(
+        `kild: memory synthesis spawn failed for '${room.name}': ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 
   /** Spawn one participant session, wired so its control lines route back here.
@@ -436,6 +496,16 @@ export class RoomManager {
     if (room.participants[0]?.sessionId !== sessionId) {
       return fail('rejected', `only the lead may close room '${room.name}'`);
     }
+    // No force on the participant path: an agent may not bury a raised decision. Only
+    // the operator (human/brain) can force-close past open decisions.
+    if (openDecisions(room).length > 0) {
+      return fail(
+        'rejected',
+        `room '${room.name}' has open decisions: ${formatOpenDecisions(room)}. ` +
+          `Get each resolved (a 'resolved[<key>]: <how>' post) before closing; ` +
+          `only the operator may force-close past them.`,
+      );
+    }
     await this.post(
       room.id,
       HUMAN,
@@ -489,6 +559,9 @@ export class RoomManager {
       );
     }
 
+    // Fold decision markers BEFORE the append — appendMessage's write-through snapshot
+    // then persists the updated ledger together with the post that changed it.
+    applyDecisionMarkers(room, message);
     traceRoomPost(room.name, message);
     this.registry.appendMessage(roomId, message);
     routeRoomMessage(room, message, this.delivery());

--- a/engine/src/kild/room/room-registry.ts
+++ b/engine/src/kild/room/room-registry.ts
@@ -2,12 +2,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { kildHome } from '../config.ts';
-import type {
-  ArchivedRoom,
-  Room,
-  RoomMessage,
-  RoomParticipant,
-  RoomSummary,
+import {
+  type ArchivedRoom,
+  participantView,
+  type Room,
+  type RoomMessage,
+  type RoomParticipant,
+  type RoomSummary,
 } from './room-types.ts';
 
 /**
@@ -71,12 +72,19 @@ export class RoomRegistry {
     this.save(room); // write-through: the log (and current participant snapshot) to disk
   }
 
+  /** Re-persist a room's snapshot after out-of-band metadata changes (e.g. a participant's
+   *  pi session identity arriving after the last post). No-op for message-less rooms. */
+  persistNow(roomId: string): void {
+    const room = this.rooms.get(roomId);
+    if (room) this.save(room);
+  }
+
   summaries(): RoomSummary[] {
     return [...this.rooms.values()].map((r) => ({
       id: r.id,
       name: r.name,
       worktree: r.worktree,
-      participants: r.participants.map((p) => ({ name: p.name, agent: p.agent, model: p.model })),
+      participants: r.participants.map(participantView),
       state: r.state,
       stopped: r.state === 'halted',
     }));
@@ -95,9 +103,10 @@ export class RoomRegistry {
       id: r.id,
       name: r.name,
       worktree: r.worktree,
-      participants: r.participants.map((p) => ({ name: p.name, agent: p.agent, model: p.model })),
+      participants: r.participants.map(participantView),
       state: r.state,
       log: r.log,
+      decisions: r.decisions,
     }));
   }
 
@@ -117,13 +126,10 @@ export class RoomRegistry {
       id: room.id,
       name: room.name,
       worktree: room.worktree,
-      participants: room.participants.map((p) => ({
-        name: p.name,
-        agent: p.agent,
-        model: p.model,
-      })),
+      participants: room.participants.map(participantView),
       state,
       log: room.log,
+      decisions: room.decisions,
     };
   }
 

--- a/engine/src/kild/room/room-types.ts
+++ b/engine/src/kild/room/room-types.ts
@@ -1,5 +1,6 @@
 import type { UiEvent } from '../events.ts';
 import type { WorkstreamGitStatus } from '../worktree-status.ts';
+import type { RoomDecision } from './room-decisions.ts';
 
 /**
  * Room domain — the operator-facing primitive: a set of participants (agent
@@ -29,6 +30,13 @@ export interface RoomParticipant {
    *  the opener's initial roster. Ground-truth spawn edge (vs inferring it from the log)
    *  and the routing target for its idle/done notice. */
   invitedBy?: string;
+  /** The underlying pi session id — the durable terminal-resume handle
+   *  (`pi --session <piSessionFile ?? piSessionId>`). Captured from the worker's
+   *  `pi_session` event and persisted with the room, so any agent in any room —
+   *  live or archived — can be reopened in the pi CLI. */
+  piSessionId?: string;
+  /** Absolute pi session file path (resume works from any cwd). */
+  piSessionFile?: string;
   /** Runtime-only: true when the session has finished a turn and is waiting. Set on
    *  `agent_end`, cleared when a new prompt is delivered. Dedups the idle failsafe to
    *  one check per active→idle transition; never serialized. */
@@ -40,11 +48,26 @@ export interface RoomParticipant {
 }
 
 /** A participant as surfaced to observers (room lists, status, archive) — identity plus
- *  the model it ran on. No sessionId (that's an internal handle). */
+ *  the model it ran on. No kild sessionId (that's an internal handle); the PI session
+ *  identity IS exposed — it's the durable handle for reopening the agent in a terminal. */
 export interface ParticipantView {
   name: string;
   agent?: string;
   model?: string;
+  piSessionId?: string;
+  piSessionFile?: string;
+}
+
+/** The one mapping from a live participant to its observer view — every list/status/
+ *  archive producer uses this so new view fields appear everywhere at once. */
+export function participantView(participant: RoomParticipant): ParticipantView {
+  return {
+    name: participant.name,
+    agent: participant.agent,
+    model: participant.model,
+    piSessionId: participant.piSessionId,
+    piSessionFile: participant.piSessionFile,
+  };
 }
 
 /** A single post on a room's shared log — the conversation unit. */
@@ -87,6 +110,9 @@ export interface Room {
   log: RoomMessage[];
   /** Canonical lifecycle state for this room. */
   state: RoomLifecycleState;
+  /** Keyed decision ledger folded from `needs-decision[key]:` / `resolved[key]` post
+   *  markers (see room-decisions). Optional so out-of-scope fixtures stay untouched. */
+  decisions?: RoomDecision[];
 }
 
 /** A participant to spawn into a room. */
@@ -135,6 +161,8 @@ export interface ArchivedRoom {
    *  older history files and out-of-scope fixtures continue to type-check. */
   state?: RoomLifecycleState;
   log: RoomMessage[];
+  /** Keyed decision ledger (see room-decisions). Optional: older history files predate it. */
+  decisions?: RoomDecision[];
 }
 
 /** A live room enriched with its workstream's git/worktree state — the code-state

--- a/engine/src/kild/sessions.ts
+++ b/engine/src/kild/sessions.ts
@@ -45,6 +45,11 @@ export interface SessionInfo {
   branch?: string;
   /** Deterministic on-disk worktree path, when the session runs in a worktree. */
   worktreePath?: string;
+  /** The underlying pi session id — reopen this agent in a terminal with
+   *  `pi --session <piSessionFile ?? piSessionId>`. */
+  piSessionId?: string;
+  /** Absolute pi session file path (the robust resume handle; works from any cwd). */
+  piSessionFile?: string;
 }
 
 /** A message broadcast to every connected client. */
@@ -238,6 +243,13 @@ export class SessionManager {
       id,
       req,
       (event) => {
+        // Capture the pi session's durable identity so any client can offer a
+        // terminal resume (`pi --session …`) for this agent.
+        if (event.kind === 'pi_session') {
+          info.piSessionId = event.id;
+          info.piSessionFile = event.file;
+          this.broadcast({ sessions: this.list() });
+        }
         this.broadcast({ session: id, event });
         if (event.kind === 'session_end') {
           this.sessions.delete(id);

--- a/engine/src/server.ts
+++ b/engine/src/server.ts
@@ -381,17 +381,23 @@ app.post('/api/rooms/:id/post', async (c) => {
   return c.json({ ok: true, message: result.value.message });
 });
 app.post('/api/rooms/:id/close', async (c) => {
-  const { from, sessionId } = await c.req.json<{ from?: unknown; sessionId?: unknown }>();
+  const { from, sessionId, force } = await c.req.json<{
+    from?: unknown;
+    sessionId?: unknown;
+    force?: unknown;
+  }>();
   if (from !== undefined && typeof from !== 'string')
     return c.json({ error: 'from must be a string' }, 400);
   if (sessionId !== undefined && typeof sessionId !== 'string')
     return c.json({ error: 'sessionId must be a string' }, 400);
+  if (force !== undefined && typeof force !== 'boolean')
+    return c.json({ error: 'force must be a boolean' }, 400);
   const attribution = resolveCloseRoomActor(
     { from: typeof from === 'string' ? from : undefined, sessionId },
     sessionManager,
   );
   if (!attribution.ok) return c.json({ error: attribution.message }, roomResultStatus(attribution));
-  const result = await roomManager.close(c.req.param('id'));
+  const result = await roomManager.close(c.req.param('id'), { force: force === true });
   if (!result.ok) return c.json({ error: result.message }, roomResultStatus(result));
   return c.json({ ok: true, message: result.value.message });
 });

--- a/engine/src/worker.ts
+++ b/engine/src/worker.ts
@@ -20,6 +20,7 @@ import {
   formatModelsSection,
   MECHANISM_PROMPT,
 } from './kild/mechanism-prompt.ts';
+import { fleetMemorySection, projectMemorySection } from './kild/memory.ts';
 import { resolveModel, withRole } from './kild/models.ts';
 import { createCloseRoomTool } from './kild/room/close-room-tool.ts';
 import { createInviteAgentTool } from './kild/room/invite-agent-tool.ts';
@@ -152,6 +153,13 @@ export async function runWorker(): Promise<never> {
     process.exit(1);
   }
   if (model) emit({ kind: 'model', provider: model.provider, id: model.id });
+  // The pi session's durable identity — lets an operator reopen this exact agent in the
+  // terminal with `pi --session <file|id>` (the file path works from any cwd).
+  emit({
+    kind: 'pi_session',
+    id: session.sessionManager.getSessionId(),
+    file: session.sessionManager.getSessionFile(),
+  });
 
   session.subscribe((e: RawAgentEvent) => {
     const ui = translate(e);
@@ -187,9 +195,15 @@ export async function runWorker(): Promise<never> {
   // pick a model per fan-out agent.
   const modelsSection =
     inRoom || fleetEnabled ? formatModelsSection(await configuredModels(cwd)) : '';
-  let sessionPrefix: string | null = modelsSection
-    ? `${MECHANISM_PROMPT}\n\n${modelsSection}`
-    : MECHANISM_PROMPT;
+  // Persistent memory rides the first turn: fleet drivers get the operator's cross-project
+  // memory; every session gets the project's curated memory + direction (read from the
+  // MAIN checkout — the files are gitignored, so worktree checkouts never carry them).
+  const memorySections = [fleetEnabled ? fleetMemorySection() : '', projectMemorySection(cwd)]
+    .filter(Boolean)
+    .join('\n\n');
+  let sessionPrefix: string | null = [MECHANISM_PROMPT, modelsSection, memorySections]
+    .filter(Boolean)
+    .join('\n\n');
 
   // pi runs one turn at a time. A room can deliver a message (prompt) to this
   // participant while it is still mid-turn, so we queue prompts and drain them

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -93,14 +93,41 @@ interface GitStatus {
   conflictsWithBase: boolean | null;
   error?: string;
 }
+interface RoomDecision {
+  key: string;
+  summary: string;
+  openedBy: string;
+  resolvedAt?: number;
+}
 interface LiveRoom {
   id: string;
   name: string;
   worktree?: string;
   state?: string;
-  participants: Array<{ name: string; agent?: string; model?: string }>;
-  log: Array<{ from: string; to: string[]; text: string; system?: boolean; implicit?: boolean }>;
+  participants: Array<{
+    name: string;
+    agent?: string;
+    model?: string;
+    piSessionId?: string;
+    piSessionFile?: string;
+  }>;
+  log: Array<{
+    id?: string;
+    from: string;
+    to: string[];
+    text: string;
+    system?: boolean;
+    implicit?: boolean;
+  }>;
   git?: GitStatus;
+  decisions?: RoomDecision[];
+}
+
+function openDecisionsLine(room: LiveRoom): string {
+  const open = (room.decisions ?? []).filter((d) => d.resolvedAt === undefined);
+  if (open.length === 0) return '';
+  const rendered = open.map((d) => `${d.key} (${d.summary}, raised by @${d.openedBy})`).join('; ');
+  return `\n    OPEN DECISIONS: ${rendered}`;
 }
 
 function gitLine(g?: GitStatus): string {
@@ -113,6 +140,16 @@ function participantLine(room: LiveRoom): string {
   return room.participants
     .map((p) => (p.model ? `${p.name}:${p.model}` : p.name))
     .join(', ');
+}
+
+/** Terminal-resume handles for a room's agents — any agent session can be reopened in a
+ *  normal pi CLI with `pi --session <file>` (full context, works from any cwd). */
+function resumeLines(room: LiveRoom): string {
+  const withHandles = room.participants.filter((p) => p.piSessionFile ?? p.piSessionId);
+  if (withHandles.length === 0) return '';
+  return withHandles
+    .map((p) => `\n    resume @${p.name}: pi --session ${p.piSessionFile ?? p.piSessionId}`)
+    .join('');
 }
 
 function truncate(text: string): string {
@@ -138,6 +175,21 @@ function modelCatalog(): string {
   return lines.length ? `\nParticipant models (pick per task — fit over cost):\n${lines.join('\n')}` : '';
 }
 
+/** The operator's cross-project memory ($KILD_HOME/MAIN_MEMORY.md), capped — the pi
+ *  driver is a fleet operator, so it gets the same fleet memory an engine-spawned driver
+ *  gets. Empty string when absent. */
+function fleetMemory(): string {
+  const home = process.env.KILD_HOME ?? path.join(os.homedir(), '.config', 'kild');
+  try {
+    const content = fs.readFileSync(path.join(home, 'MAIN_MEMORY.md'), 'utf8').trim();
+    if (!content) return '';
+    const capped = content.length > 6000 ? `${content.slice(0, 6000)}…` : content;
+    return `\n\n<fleet-memory>\nYour cross-project fleet memory ($KILD_HOME/MAIN_MEMORY.md):\n${capped}\n</fleet-memory>`;
+  } catch {
+    return '';
+  }
+}
+
 function driverGuide(): string {
   return `<kild-fleet-driver>
 You can orchestrate CONCURRENT multi-agent workstreams ("rooms") via the kild_* tools. You
@@ -155,11 +207,15 @@ are the operator/driver: rooms do the work; you open, delegate, observe, and lan
   with kild_room_post.
 - NEVER call kild_room_close unless the human explicitly tells you to close — closing kills
   every agent's context irrecoverably. Finished rooms stay open for follow-up.
+- Rooms carry keyed decisions: a participant's \`needs-decision[<key>]: <question>\` post
+  opens one; it stays visible in kild_rooms and BLOCKS close until someone posts
+  \`resolved[<key>]: <how>\`. When you make the call, post the resolved line into the room.
+  Never force-close past open decisions without the human's explicit say-so.
 - For a long campaign you won't drive yourself, hand off to a detached driver with
   kild_fleet_start (steer with kild_fleet_post, list with kild_sessions); its rooms outlive it.
 - kild_agents lists the personas valid for participants; "default" always works.
 ${modelCatalog()}
-</kild-fleet-driver>`;
+</kild-fleet-driver>${fleetMemory()}`;
 }
 
 // ── completion push: engine WS → injected turns ─────────────────────────────────────
@@ -217,6 +273,54 @@ function pushReport(text: string): void {
 
 let ws: WebSocket | undefined;
 let lastBootId: string | undefined;
+let everConnected = false;
+const notifiedGone = new Set<string>();
+
+/** Catch up after a WS gap: events pushed while the socket was down are gone, so on every
+ *  RE-connect pull `/api/rooms/live` once and reconcile the engaged rooms — push any
+ *  missed report-to-human (deduped via seenReports) and say so once for an engaged room
+ *  that is no longer live (closed, or died with an engine restart). Pull-based on
+ *  purpose: no engine-side outbox/ack machinery for a gap this rare. */
+async function reconcileAfterReconnect(): Promise<void> {
+  if (engagedRooms.size === 0) return;
+  let rooms: LiveRoom[];
+  try {
+    const r = await fetch(`${ENGINE}/api/rooms/live`, { signal: AbortSignal.timeout(5000) });
+    if (!r.ok) throw new Error(String(r.status));
+    rooms = (await r.json()) as LiveRoom[];
+  } catch (e) {
+    dbg(`reconcile: fetch failed — ${(e as Error).message}`);
+    return;
+  }
+  const liveById = new Map(rooms.map((r) => [r.id, r]));
+  for (const roomId of engagedRooms) {
+    const room = liveById.get(roomId);
+    if (!room) {
+      if (notifiedGone.has(roomId)) continue;
+      notifiedGone.add(roomId);
+      const name = roomNames.get(roomId) ?? roomId.slice(0, 8);
+      dbg(`reconcile: engaged room "${name}" no longer live — notifying`);
+      pushReport(
+        `[kild] room "${name}" (${roomId}) is no longer live — it was closed, or its agents ` +
+          `died with an engine restart, while the report bridge was down. Use kild_rooms for ` +
+          `current state and re-open a room if the workstream is unfinished.`,
+      );
+      continue;
+    }
+    roomNames.set(room.id, room.name);
+    for (const m of room.log) {
+      if (!m.id || m.system || m.implicit || !m.to?.includes('human')) continue;
+      if (seenReports.has(m.id)) continue;
+      seenReports.add(m.id);
+      dbg(`reconcile: missed report in "${room.name}" from ${m.from} — pushing`);
+      pushReport(
+        `[kild] room "${room.name}" (${room.id}) — @${m.from} reports (delivered late; the ` +
+          `report bridge was down):\n${m.text}\n\n` +
+          `(React if action is needed; the room stays open and idle for follow-up.)`,
+      );
+    }
+  }
+}
 
 /** Force a fresh WS, dropping any existing one (used on restart detection / reconnect). */
 function reconnect(): void {
@@ -242,7 +346,11 @@ function connectWs(): void {
     return;
   }
   ws = sock;
-  sock.onopen = () => dbg(`ws: open (${engagedRooms.size} engaged rooms)`);
+  sock.onopen = () => {
+    dbg(`ws: open (${engagedRooms.size} engaged rooms)`);
+    if (everConnected) void reconcileAfterReconnect();
+    everConnected = true;
+  };
   sock.onmessage = (ev) => {
       try {
         const msg = JSON.parse(String(ev.data)) as {
@@ -408,7 +516,7 @@ export default function (pi: PiExtensionAPI) {
       const lines = rooms.map((r) => {
         const last = r.log.filter((m) => !m.system).at(-1);
         const lastLine = last ? `\n    last: ${last.from} → [${last.to.join(', ')}]: ${last.text.replace(/\s+/g, ' ').slice(0, 120)}` : '';
-        return `${r.id}\n    ${r.name} [${participantLine(r)}]${gitLine(r.git)}${lastLine}`;
+        return `${r.id}\n    ${r.name} [${participantLine(r)}]${gitLine(r.git)}${openDecisionsLine(r)}${resumeLines(r)}${lastLine}`;
       });
       return { content: [{ type: 'text', text: truncate(lines.join('\n')) }], details: { count: rooms.length } };
     },
@@ -467,16 +575,25 @@ export default function (pi: PiExtensionAPI) {
     description:
       'Close a kild room: stops every agent and archives the transcript. DESTRUCTIVE — all ' +
       "agent context is lost forever. Call ONLY when the human explicitly says to close. " +
-      'Finished rooms should stay open (idle) for follow-up.',
+      'Finished rooms should stay open (idle) for follow-up. A room with open decisions ' +
+      'refuses to close: get each resolved (a "resolved[<key>]: <how>" post), or pass ' +
+      'force ONLY when the human explicitly says to abandon them.',
     parameters: Type.Object({
       id: Type.String({ description: 'Room id.' }),
+      force: Type.Optional(
+        Type.Boolean({
+          description:
+            'Close past open decisions. Only on an explicit human instruction — this buries ' +
+            'unresolved decisions.',
+        }),
+      ),
     }),
     async execute(_id, params) {
-      const p = params as { id: string };
+      const p = params as { id: string; force?: boolean };
       const res = await engineFetch<{ message: string }>(`/api/rooms/${encodeURIComponent(p.id)}/close`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify(p.force ? { force: true } : {}),
       });
       return { content: [{ type: 'text', text: res.message }] };
     },


### PR DESCRIPTION
## What this is

The "kild remembers" spine: per-project memory that agents actually receive, an engine-written factual log of every closed room, and an optional LLM synthesis pass that keeps a lean curated memory current. Ships with two enabling slices in the same state model: **keyed decisions** (a raised `needs-decision` can never be silently buried, and blocks room close until resolved) and **pi resume handles** (every agent session — live or archived — reopenable in a plain pi terminal).

## The memory model

Two layers, two owners — deliberately split so facts never depend on an LLM:

| File | Owner | What |
|---|---|---|
| `<project>/.kild/LOG.md` | **engine** (always on) | Append-only; one entry per closed room: goal, outcome, every decision + who resolved it, each agent with model and `pi --session` resume handle, worktree/base |
| `<project>/.kild/MEMORY.md` | synthesis session (opt-in) | Lean curated memory: key decisions, human calls, learnings, direction (~120 lines, compressed on every rewrite) |
| `<project>/.kild/direction.md` | **human** | Product direction; agents read it, never write it |
| `$KILD_HOME/MAIN_MEMORY.md` | operator | Cross-project fleet memory for driver/brain sessions |

Injection: `MEMORY.md` + `direction.md` ride every session's first turn (capped at 6KB each); fleet drivers (engine-spawned and the pi-extension driver) additionally get `MAIN_MEMORY.md`. Memory files are **personal for now**: an auto-written `.kild/.gitignore` covers them (`MEMORY.md`, `LOG.md`, `direction.md`, `.memory-state.json`) — flip that file when team-shared memory becomes a thing. Because they're gitignored they never appear in worktree checkouts, so all reads/writes are pinned to the project's MAIN checkout.

## Setup guide

1. **Nothing to enable for the log.** From this branch on, every room close appends its entry to `<project>/.kild/LOG.md` automatically.

2. **Turn on synthesis** (per project, or globally in `$KILD_HOME/config.json`):

   ```jsonc
   // <project>/.kild/config.json
   {
     "memory": {
       "synthesis": {
         "model": "openai-codex/gpt-5.6-terra",  // pick a strong reasoning model
         "agent": "default"                        // or a memorist persona from .pi/agents/
       }
     }
   }
   ```

   On every room close (agent told to close, cockpit/CLI close, fleet `close_room`), the engine appends the LOG.md entry, then spawns one session in the project's main checkout with a fixed charter: read the room transcript (`$KILD_HOME/rooms/<id>.json`), rewrite `.kild/MEMORY.md` lean; `direction.md` is read-only; touch nothing else. No config → log only, no session spawned.

3. **Seed the operator memory** (optional): create `$KILD_HOME/MAIN_MEMORY.md` (`~/.config/kild/MAIN_MEMORY.md` by default) with one entry per project — name, one-line description, where it lives. Fleet drivers get it in their guide from then on.

4. **Steer the product** (optional): write `<project>/.kild/direction.md`; every session in that project sees it.

5. **Teach the crew about decisions** — nothing to do: the mechanism prompt now instructs every session to mark human-needed calls as `needs-decision[<key>]: <question>` and to post `resolved[<key>]: <how>` when the call is made. Open decisions show in `rooms_status`/`kild_rooms` and refuse `close_room` (operator `force` overrides; the room lead never can).

6. **Reopen any agent in a terminal**: `kild_rooms` now prints `resume @worker: pi --session <file>` per agent. Works for archived rooms too — the handles persist in the room snapshot. (Don't resume a session whose room is still live — two writers on one session file.)

## Notes for review

- Decision grammar lives in one module (`room-decisions.ts`), same pattern as `parseMentions`; the fold happens before the write-through save so the ledger persists with the post that changed it.
- Memory failures log to the engine console and never break a close.
- The pi-extension bridge also gained reconnect reconciliation: after a WS gap it pulls `/api/rooms/live` once, pushes missed `@human` reports (deduped) and a notice for engaged rooms that died with an engine restart.
- Known limitation, deliberate: synthesis triggers only on **manual** close — there is no automatic "room is done" signal yet; that's a lifecycle question to solve separately, and the hook already sits on the right chokepoint (`close()`).

## Validation

`tsc --noEmit` clean · `biome check` clean · `bun test`: **157 pass** (25 new: decision grammar + fold invariants, close refusal/force paths, pi-handle capture + archive persistence, log format, gitignore non-clobber, synthesis spawn gating) · pi-extension bundles.