### PR TITLE
feat(engine): configurable memory dir + fork-spawn from a pi session file

### DIFF
--- a/engine/src/kild/config.test.ts
+++ b/engine/src/kild/config.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { resolvePluginPaths } from './config.ts';
+import { configuredMemoryDir, resolvePluginPaths } from './config.ts';
 
 let tmp: string;
 let prevHome: string | undefined;
@@ -54,6 +54,44 @@ test('global ($KILD_HOME) and project configs both contribute', async () => {
   expect(skillDirs).toContain(path.join(proj, 'local', 'skills'));
 });
 
+test('memory.dir defaults to .kild resolved against the project cwd', async () => {
+  const proj = path.join(tmp, 'proj-mem-default');
+  fs.mkdirSync(proj, { recursive: true });
+  expect(await configuredMemoryDir(proj)).toBe(path.join(proj, '.kild'));
+});
+
+test('a relative memory.dir resolves against the project cwd', async () => {
+  const proj = path.join(tmp, 'proj-mem-rel');
+  writeProjectConfig(proj, { memory: { dir: 'notes/kild' } });
+  expect(await configuredMemoryDir(proj)).toBe(path.join(proj, 'notes', 'kild'));
+});
+
+test('an absolute memory.dir is taken as-is and ~ expands to $HOME', async () => {
+  const proj = path.join(tmp, 'proj-mem-abs');
+  writeProjectConfig(proj, { memory: { dir: '/stores/proj-a' } });
+  expect(await configuredMemoryDir(proj)).toBe('/stores/proj-a');
+
+  const proj2 = path.join(tmp, 'proj-mem-home');
+  writeProjectConfig(proj2, { memory: { dir: '~/stores/proj-a' } });
+  expect(await configuredMemoryDir(proj2)).toBe(
+    path.join(process.env.HOME ?? '', 'stores', 'proj-a'),
+  );
+});
+
+test('project memory.dir wins over global; global applies when the project sets none', async () => {
+  fs.writeFileSync(
+    path.join(process.env.KILD_HOME as string, 'config.json'),
+    JSON.stringify({ memory: { dir: '/global/store' } }),
+  );
+  const proj = path.join(tmp, 'proj-mem-merge');
+  writeProjectConfig(proj, { memory: { dir: '/project/store' } });
+  expect(await configuredMemoryDir(proj)).toBe('/project/store');
+
+  const bare = path.join(tmp, 'proj-mem-bare');
+  fs.mkdirSync(bare, { recursive: true });
+  expect(await configuredMemoryDir(bare)).toBe('/global/store');
+});
+
 test('missing or malformed config yields nothing and never throws', async () => {
   const proj = path.join(tmp, 'noconfig');
   fs.mkdirSync(proj, { recursive: true });
@@ -61,4 +99,5 @@ test('missing or malformed config yields nothing and never throws', async () => 
 
   writeProjectConfig(proj, 'not an object');
   expect(await resolvePluginPaths(proj)).toEqual({ agentDirs: [], skillDirs: [] });
+  expect(await configuredMemoryDir(proj)).toBe(path.join(proj, '.kild')); // falls back to default
 });

--- a/engine/src/kild/config.ts
+++ b/engine/src/kild/config.ts
@@ -34,10 +34,15 @@ export interface KildConfig {
    *  it's good at, cost). Appended to a delegating session's system prompt so the user
    *  and the orchestrator can steer which models fan-out agents run on. Order = preference. */
   models?: Record<string, string>;
-  /** Project memory behavior. The engine-written room log (`.kild/LOG.md`) is always on;
+  /** Project memory behavior. The engine-written room log (`<dir>/LOG.md`) is always on;
    *  `synthesis` opts in to the LLM half: on room close, a session is spawned to distill
-   *  the transcript into `.kild/MEMORY.md`. Absent → no synthesis session is spawned. */
+   *  the transcript into `<dir>/MEMORY.md`. Absent → no synthesis session is spawned. */
   memory?: {
+    /** Directory holding the project's memory files (LOG.md, MEMORY.md, direction.md).
+     *  `~` expands to $HOME; a relative path resolves against the project cwd.
+     *  Default: `.kild` — the project-local store. Any intelligence layer can point
+     *  this anywhere; to kild it is just a directory path. */
+    dir?: string;
     synthesis?: {
       /** provider/model ref for the synthesis session (pick a strong reasoning model). */
       model?: string;
@@ -113,6 +118,16 @@ export async function configuredModels(cwd: string): Promise<Record<string, stri
   const global = await readConfigFile(path.join(kildHome(), 'config.json'));
   const project = await readConfigFile(path.join(cwd, '.kild', 'config.json'));
   return { ...(global?.models ?? {}), ...(project?.models ?? {}) };
+}
+
+/** The resolved memory directory for `cwd`: config `memory.dir`, project over global,
+ *  default `.kild`. `~` expands to $HOME; a relative value resolves against `cwd`.
+ *  Always returns an absolute path. Never throws. */
+export async function configuredMemoryDir(cwd: string): Promise<string> {
+  const project = await readConfigFile(path.join(cwd, '.kild', 'config.json'));
+  const global = await readConfigFile(path.join(kildHome(), 'config.json'));
+  const dir = project?.memory?.dir ?? global?.memory?.dir ?? '.kild';
+  return path.resolve(cwd, expandHome(dir));
 }
 
 /** Merged memory-synthesis config (project wins over global); undefined = synthesis off. */

--- a/engine/src/kild/fleet/engine-client.ts
+++ b/engine/src/kild/fleet/engine-client.ts
@@ -80,6 +80,9 @@ export interface SpawnSessionRequest {
   projectName?: string;
   /** Grant the fleet room-control tools (open/post/status/close rooms). */
   fleet?: boolean;
+  /** Absolute pi session file to fork from — the spawned session starts from a frozen
+   *  copy of its history (a new session file; the source is never written). */
+  forkFrom?: string;
   /** Initial prompt delivered right after spawn (e.g. the fleet driver's goal). */
   prompt?: string;
 }

--- a/engine/src/kild/memory.test.ts
+++ b/engine/src/kild/memory.test.ts
@@ -97,40 +97,65 @@ test('the log entry carries goal, outcome, decisions, resume handles, worktree â
   expect(entry).toContain('- worktree: kild/fix-auth (base main)');
 });
 
-test('appendRoomLog creates .kild with a memory .gitignore and appends in order', () => {
+test('appendRoomLog creates the memory dir with a .gitignore and appends in order', () => {
   const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
-  appendRoomLog(room(project), new Date('2026-07-24T12:00:00Z'));
-  appendRoomLog(room(project, { id: 'room-2', name: 'second' }), new Date('2026-07-25T12:00:00Z'));
+  const dir = path.join(project, '.kild');
+  appendRoomLog(room(project), dir, new Date('2026-07-24T12:00:00Z'));
+  appendRoomLog(
+    room(project, { id: 'room-2', name: 'second' }),
+    dir,
+    new Date('2026-07-25T12:00:00Z'),
+  );
 
-  const log = fs.readFileSync(path.join(project, '.kild', 'LOG.md'), 'utf8');
+  const log = fs.readFileSync(path.join(dir, 'LOG.md'), 'utf8');
   expect(log.indexOf('fix-auth')).toBeLessThan(log.indexOf('second'));
 
-  const gitignore = fs.readFileSync(path.join(project, '.kild', '.gitignore'), 'utf8');
+  const gitignore = fs.readFileSync(path.join(dir, '.gitignore'), 'utf8');
   for (const name of ['MEMORY.md', 'LOG.md', 'direction.md', '.memory-state.json']) {
     expect(gitignore).toContain(name);
   }
 });
 
-test('an existing .kild/.gitignore is never clobbered', () => {
+test('an existing memory-dir .gitignore is never clobbered', () => {
   const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
-  fs.mkdirSync(path.join(project, '.kild'), { recursive: true });
-  fs.writeFileSync(path.join(project, '.kild', '.gitignore'), '# user-managed\n');
-  appendRoomLog(room(project));
-  expect(fs.readFileSync(path.join(project, '.kild', '.gitignore'), 'utf8')).toBe(
-    '# user-managed\n',
-  );
+  const dir = path.join(project, '.kild');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.gitignore'), '# user-managed\n');
+  appendRoomLog(room(project), dir);
+  expect(fs.readFileSync(path.join(dir, '.gitignore'), 'utf8')).toBe('# user-managed\n');
+});
+
+test('a memory dir outside the project gets the log but NO .gitignore', () => {
+  const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
+  const external = fs.mkdtempSync(path.join(tmp, 'store-')); // e.g. a user-home store
+  appendRoomLog(room(project), external, new Date('2026-07-24T12:00:00Z'));
+
+  expect(fs.readFileSync(path.join(external, 'LOG.md'), 'utf8')).toContain('fix-auth');
+  expect(fs.existsSync(path.join(external, '.gitignore'))).toBe(false);
+  expect(fs.existsSync(path.join(project, '.kild'))).toBe(false); // nothing written in-project
 });
 
 test('projectMemorySection composes MEMORY.md + direction.md and is empty when absent', () => {
   const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
-  expect(projectMemorySection(project)).toBe('');
-  fs.mkdirSync(path.join(project, '.kild'), { recursive: true });
-  fs.writeFileSync(path.join(project, '.kild', 'MEMORY.md'), 'Auth uses tokens.');
-  fs.writeFileSync(path.join(project, '.kild', 'direction.md'), 'Ship v2 by fall.');
-  const section = projectMemorySection(project);
+  const dir = path.join(project, '.kild');
+  expect(projectMemorySection(project, dir)).toBe('');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'MEMORY.md'), 'Auth uses tokens.');
+  fs.writeFileSync(path.join(dir, 'direction.md'), 'Ship v2 by fall.');
+  const section = projectMemorySection(project, dir);
   expect(section).toContain('<project-memory>');
+  expect(section).toContain('(.kild/MEMORY.md)'); // default dir reads project-relative
   expect(section).toContain('Auth uses tokens.');
   expect(section).toContain('Ship v2 by fall.');
+});
+
+test('projectMemorySection reads an external memory dir and names its actual paths', () => {
+  const project = fs.mkdtempSync(path.join(tmp, 'proj-'));
+  const external = fs.mkdtempSync(path.join(tmp, 'store-'));
+  fs.writeFileSync(path.join(external, 'MEMORY.md'), 'Lives outside the repo.');
+  const section = projectMemorySection(project, external);
+  expect(section).toContain('Lives outside the repo.');
+  expect(section).toContain(`(${path.join(external, 'MEMORY.md')})`);
 });
 
 test('fleetMemorySection reads $KILD_HOME/MAIN_MEMORY.md and is empty when absent', () => {
@@ -144,9 +169,17 @@ test('fleetMemorySection reads $KILD_HOME/MAIN_MEMORY.md and is empty when absen
 });
 
 test('the synthesis charter names the transcript, the memory file, and the constraints', () => {
-  const prompt = synthesisPrompt(room('/p'), '/home/rooms/room-1.json');
+  const prompt = synthesisPrompt(room('/p'), '/home/rooms/room-1.json', '/p/.kild');
   expect(prompt).toContain('[kild memory synthesis]');
   expect(prompt).toContain('/home/rooms/room-1.json');
   expect(prompt).toContain('.kild/MEMORY.md');
   expect(prompt).toContain('READ-ONLY');
+});
+
+test('the synthesis charter names the ACTUAL configured paths for an external dir', () => {
+  const prompt = synthesisPrompt(room('/p'), '/home/rooms/room-1.json', '/stores/proj');
+  expect(prompt).toContain('/stores/proj/MEMORY.md');
+  expect(prompt).toContain('/stores/proj/LOG.md');
+  expect(prompt).toContain('/stores/proj/direction.md');
+  expect(prompt).not.toContain('.kild/MEMORY.md');
 });

--- a/engine/src/kild/memory.ts
+++ b/engine/src/kild/memory.ts
@@ -9,20 +9,23 @@ import type { Room } from './room/room-types.ts';
 /**
  * Project memory — the filesystem half of "kild remembers".
  *
+ * All files live in the project's memory dir (config `memory.dir`, default `.kild/`
+ * in the project — callers resolve it via `configuredMemoryDir` and pass it in).
  * Two layers with different owners, deliberately split:
  *
- * - `.kild/LOG.md` — append-only, ENGINE-written: one entry per closed room, built
+ * - `LOG.md` — append-only, ENGINE-written: one entry per closed room, built
  *   entirely from structured state the engine already holds (goal, outcome, decisions,
  *   agents + their pi resume handles, worktree). Free, instant, never hallucinates.
- * - `.kild/MEMORY.md` — lean CURATED memory, written by an optional synthesis session
+ * - `MEMORY.md` — lean CURATED memory, written by an optional synthesis session
  *   (config `memory.synthesis`) that reads the transcript and distills judgment-work:
- *   learnings, direction, the why behind decisions. `.kild/direction.md` is human-owned
+ *   learnings, direction, the why behind decisions. `direction.md` is human-owned
  *   product direction; the engine only ever reads it.
  *
  * Fleet-level memory is `$KILD_HOME/MAIN_MEMORY.md` — the operator's cross-project
- * index. All memory files are personal for now (gitignored via `.kild/.gitignore`),
- * which also means worktree checkouts don't carry them: memory is always read from and
- * written to the project's MAIN checkout (`room.cwd`), never a worktree.
+ * index. All memory files are personal for now (a project-internal dir is gitignored
+ * via its own `.gitignore`; an external dir needs none), which also means worktree
+ * checkouts don't carry them: memory is always read from and written to the project's
+ * MAIN checkout (`room.cwd`), never a worktree.
  */
 
 const MEMORY_GITIGNORE = ['MEMORY.md', 'LOG.md', 'direction.md', '.memory-state.json'];
@@ -39,15 +42,31 @@ function oneLine(text: string, max: number): string {
   return truncate(text.replace(/\s+/g, ' '), max);
 }
 
-/** Ensure `.kild/` exists with a `.gitignore` covering the personal memory files.
- *  Never clobbers an existing `.gitignore` (the committed-vs-personal call is the
- *  user's to change there). */
-function ensureMemoryDir(projectCwd: string): string {
-  const dir = path.join(projectCwd, '.kild');
+/** True when `dir` sits inside `projectCwd` (the default `.kild/` case). */
+function isInsideProject(projectCwd: string, dir: string): boolean {
+  const rel = path.relative(projectCwd, dir);
+  return !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/** A memory file's path as agents should see it: relative to the project cwd when the
+ *  dir is inside the project (the default reads `.kild/LOG.md`, exactly as before),
+ *  absolute otherwise. */
+function displayPath(projectCwd: string, dir: string, file: string): string {
+  const full = path.join(dir, file);
+  return isInsideProject(projectCwd, dir) ? path.relative(projectCwd, full) : full;
+}
+
+/** Ensure the memory dir exists. A dir inside the project also gets a `.gitignore`
+ *  covering the personal memory files (never clobbering an existing one — the
+ *  committed-vs-personal call is the user's to change there); an external dir
+ *  (e.g. a user-home store) needs no gitignore. */
+function ensureMemoryDir(projectCwd: string, dir: string): string {
   fs.mkdirSync(dir, { recursive: true });
-  const gitignore = path.join(dir, '.gitignore');
-  if (!fs.existsSync(gitignore)) {
-    fs.writeFileSync(gitignore, `${MEMORY_GITIGNORE.join('\n')}\n`);
+  if (isInsideProject(projectCwd, dir)) {
+    const gitignore = path.join(dir, '.gitignore');
+    if (!fs.existsSync(gitignore)) {
+      fs.writeFileSync(gitignore, `${MEMORY_GITIGNORE.join('\n')}\n`);
+    }
   }
   return dir;
 }
@@ -78,9 +97,10 @@ export function formatRoomLogEntry(room: Room, closedAt: Date): string {
   return `${lines.join('\n')}\n\n`;
 }
 
-/** Append the room's entry to the project's `.kild/LOG.md`; returns the log path. */
-export function appendRoomLog(room: Room, closedAt: Date = new Date()): string {
-  const dir = ensureMemoryDir(room.cwd);
+/** Append the room's entry to the memory dir's `LOG.md`; returns the log path.
+ *  `dir` is the resolved memory dir (see `configuredMemoryDir`). */
+export function appendRoomLog(room: Room, dir: string, closedAt: Date = new Date()): string {
+  ensureMemoryDir(room.cwd, dir);
   const logPath = path.join(dir, 'LOG.md');
   fs.appendFileSync(logPath, formatRoomLogEntry(room, closedAt));
   return logPath;
@@ -96,15 +116,16 @@ function readCapped(file: string): string {
 }
 
 /** The project-memory prompt section (curated memory + human-owned direction), read from
- *  the project's MAIN checkout. Empty string when neither file has content. */
-export function projectMemorySection(projectCwd: string): string {
-  const dir = path.join(projectCwd, '.kild');
+ *  the resolved memory dir. Empty string when neither file has content. */
+export function projectMemorySection(projectCwd: string, dir: string): string {
   const memory = readCapped(path.join(dir, 'MEMORY.md'));
   const direction = readCapped(path.join(dir, 'direction.md'));
   if (!memory && !direction) return '';
+  const memoryPath = displayPath(projectCwd, dir, 'MEMORY.md');
+  const directionPath = displayPath(projectCwd, dir, 'direction.md');
   const parts = [
-    memory ? `Curated project memory (.kild/MEMORY.md):\n${memory}` : '',
-    direction ? `Product direction (.kild/direction.md, human-owned):\n${direction}` : '',
+    memory ? `Curated project memory (${memoryPath}):\n${memory}` : '',
+    direction ? `Product direction (${directionPath}, human-owned):\n${direction}` : '',
   ].filter(Boolean);
   return `<project-memory>\n${parts.join('\n\n')}\n</project-memory>`;
 }
@@ -118,17 +139,22 @@ export function fleetMemorySection(): string {
 }
 
 /** The synthesis session's task charter — mechanism only (what inputs, what file, what
- *  constraints); its judgment/voice comes from the configured persona, not from here. */
-export function synthesisPrompt(room: Room, transcriptPath: string): string {
+ *  constraints); its judgment/voice comes from the configured persona, not from here.
+ *  `dir` is the resolved memory dir — the charter must name the ACTUAL paths, or the
+ *  synthesis agent writes to the wrong place. */
+export function synthesisPrompt(room: Room, transcriptPath: string, dir: string): string {
+  const logPath = displayPath(room.cwd, dir, 'LOG.md');
+  const memoryPath = displayPath(room.cwd, dir, 'MEMORY.md');
+  const directionPath = displayPath(room.cwd, dir, 'direction.md');
   return (
     `[kild memory synthesis] Room '${room.name}' just closed in this project.\n\n` +
     `Inputs:\n` +
     `- Room transcript (JSON): ${transcriptPath}\n` +
-    `- Engine-written room log: .kild/LOG.md — this room's factual entry is already ` +
+    `- Engine-written room log: ${logPath} — this room's factual entry is already ` +
     `appended; do not duplicate its facts.\n` +
-    `- Current curated memory: .kild/MEMORY.md (may not exist yet)\n` +
-    `- Product direction (human-owned, READ-ONLY): .kild/direction.md (may not exist)\n\n` +
-    `Task: read the transcript, then update .kild/MEMORY.md so it stays a LEAN curated ` +
+    `- Current curated memory: ${memoryPath} (may not exist yet)\n` +
+    `- Product direction (human-owned, READ-ONLY): ${directionPath} (may not exist)\n\n` +
+    `Task: read the transcript, then update ${memoryPath} so it stays a LEAN curated ` +
     `memory of this project: key decisions and who made them (including resolved ` +
     `needs-decision[...] calls), important human calls, durable learnings, and current ` +
     `direction. Compress and rewrite — do not append-and-grow; keep it under ~120 lines ` +

--- a/engine/src/kild/room/room-manager.ts
+++ b/engine/src/kild/room/room-manager.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { listAgents } from '../agents.ts';
-import { configuredMemorySynthesis } from '../config.ts';
+import { configuredMemoryDir, configuredMemorySynthesis } from '../config.ts';
 import { appendRoomLog, roomTranscriptPath, synthesisPrompt } from '../memory.ts';
 import { type SessionCallbacks, type SpawnRequest, sessionManager } from '../sessions.ts';
 import { resolveBaseBranch, worktreePath } from '../worktree.ts';
@@ -360,11 +360,14 @@ export class RoomManager {
 
   /** Post-close memory hook: append the engine-written log entry (always), then spawn
    *  the optional synthesis session (config `memory.synthesis`) to distill the transcript
-   *  into `.kild/MEMORY.md`. Memory must never break a close — failures are logged loud
-   *  and swallowed here, at the one boundary where that is the right call. */
+   *  into the memory dir's `MEMORY.md` (config `memory.dir`, default `.kild/`). Memory
+   *  must never break a close — failures are logged loud and swallowed here, at the one
+   *  boundary where that is the right call. */
   private async recordMemory(room: Room): Promise<void> {
+    let memoryDir: string;
     try {
-      appendRoomLog(room);
+      memoryDir = await configuredMemoryDir(room.cwd);
+      appendRoomLog(room, memoryDir);
     } catch (err) {
       console.error(
         `kild: room log append failed for '${room.name}': ${err instanceof Error ? err.message : err}`,
@@ -381,7 +384,11 @@ export class RoomManager {
         agent: synthesis.agent ?? 'default',
         projectName: `memory:${room.name}`,
       });
-      this.sessions.prompt(id, synthesisPrompt(room, roomTranscriptPath(room.id)), 'kild');
+      this.sessions.prompt(
+        id,
+        synthesisPrompt(room, roomTranscriptPath(room.id), memoryDir),
+        'kild',
+      );
     } catch (err) {
       console.error(
         `kild: memory synthesis spawn failed for '${room.name}': ${err instanceof Error ? err.message : err}`,

--- a/engine/src/kild/sessions.test.ts
+++ b/engine/src/kild/sessions.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
 
-import { SessionManager } from './sessions.ts';
+import { SessionManager, workerEnv } from './sessions.ts';
 import { worktreePath, worktreeRef } from './worktree.ts';
 
 // The session path derives SessionInfo.branch/worktreePath from the worktree name
@@ -40,6 +40,21 @@ test('resolveActor rejects a live session with no actor identity', () => {
     code: 'rejected',
     message: "session 'anon-session' has no actor identity",
   });
+});
+
+test('workerEnv carries the fork source to the worker as KILD_FORK_SESSION', () => {
+  const env = workerEnv(
+    's-1',
+    { cwd: '/proj', forkFrom: '/sessions/2026-07-24_abc.jsonl' },
+    undefined,
+  );
+  expect(env.KILD_FORK_SESSION).toBe('/sessions/2026-07-24_abc.jsonl');
+  expect(env.KILD_CWD).toBe('/proj');
+  expect(env.KILD_SESSION_ID).toBe('s-1');
+});
+
+test('workerEnv leaves KILD_FORK_SESSION empty for an ordinary (fresh) spawn', () => {
+  expect(workerEnv('s-2', { cwd: '/proj' }, undefined).KILD_FORK_SESSION).toBe('');
 });
 
 test('a worktree name maps to its kild/ branch and on-disk path', () => {

--- a/engine/src/kild/sessions.ts
+++ b/engine/src/kild/sessions.ts
@@ -25,6 +25,10 @@ export interface SpawnRequest {
   /** Base branch a brand-new worktree forks from (e.g. `dev`). Ignored when attaching to
    *  an existing tree. Absent → the checkout's current HEAD. */
   base?: string;
+  /** Absolute path of an existing pi session file to fork from. The worker copies its
+   *  full history into a brand-new session file (frozen snapshot) — the source file is
+   *  never written, so the original session cannot be polluted or corrupted. */
+  forkFrom?: string;
   /** Extra environment for the worker — opaque to the manager. Room participants use
    *  it to carry `KILD_ROOM` / `KILD_PARTICIPANT`; it never overrides the `KILD_*`
    *  vars the manager itself sets. */
@@ -62,6 +66,32 @@ type MaybePromise<T> = T | Promise<T>;
 // for room participants.
 const SKILLS_PROFILE = readSkillsProfile(process.env.KILD_SKILLS_PROFILE);
 
+/** The manager-owned `KILD_*` worker environment for a spawn request. Layered on top
+ *  of `req.env`, so a request can never override the manager's own vars. Pure —
+ *  exported for tests (the request→env plumbing without spawning a worker). */
+export function workerEnv(
+  id: string,
+  req: SpawnRequest,
+  skillsProfile: string | undefined,
+): Record<string, string> {
+  return {
+    KILD_ROLE: 'worker',
+    KILD_MODEL: req.model ?? '',
+    KILD_CWD: req.cwd ?? process.cwd(),
+    KILD_AGENT: req.agent ?? '',
+    // Session identity is manager-owned: fleet tools use it to identify room openers.
+    KILD_SESSION_ID: id,
+    // The worktree *name*; the worker ensures it from KILD_CWD (the repo).
+    KILD_WORKTREE: req.worktree ?? '',
+    // Base branch a brand-new worktree forks from (empty → current HEAD).
+    KILD_BASE: req.base ?? '',
+    // pi session file to fork this session from (empty → fresh session).
+    KILD_FORK_SESSION: req.forkFrom ?? '',
+    // A profile is a room capability assignment, not inherited worker state.
+    KILD_SKILLS_PROFILE: skillsProfile ?? '',
+  };
+}
+
 /** Control-line callbacks for a session's worker — used by the RoomManager to route
  *  a participant's `post_message` / `invite_agent` back into its room. A bare
  *  (non-room) session passes none, so the control lines are simply never emitted. */
@@ -92,18 +122,7 @@ class PiSession {
       env: {
         ...parentEnv,
         ...req.env, // extra worker env (e.g. room membership); our KILD_* win below
-        KILD_ROLE: 'worker',
-        KILD_MODEL: req.model ?? '',
-        KILD_CWD: req.cwd ?? process.cwd(),
-        KILD_AGENT: req.agent ?? '',
-        // Session identity is manager-owned: fleet tools use it to identify room openers.
-        KILD_SESSION_ID: id,
-        // The worktree *name*; the worker ensures it from KILD_CWD (the repo).
-        KILD_WORKTREE: req.worktree ?? '',
-        // Base branch a brand-new worktree forks from (empty → current HEAD).
-        KILD_BASE: req.base ?? '',
-        // A profile is a room capability assignment, not inherited worker state.
-        KILD_SKILLS_PROFILE: skillsProfile ?? '',
+        ...workerEnv(id, req, skillsProfile),
       },
       stdio: ['pipe', 'pipe', 'inherit'],
     });

--- a/engine/src/server.ts
+++ b/engine/src/server.ts
@@ -6,6 +6,7 @@ if (process.env.KILD_ROLE === 'worker') {
 
 import { execFile as execFileCb } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
@@ -236,6 +237,8 @@ app.get('/api/sessions', (c) => c.json(sessionManager.list()));
 
 // Spawn a detached session (e.g. a `kild fleet` driver) — the CLI/scripts drive this over
 // REST instead of holding a WS open. `fleet: true` grants the room-control tools.
+// `forkFrom` spawns the session from a frozen copy of an existing pi session file: the
+// fork gets a NEW session file and never writes the source.
 app.post('/api/sessions', async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as {
     agent?: string;
@@ -246,7 +249,17 @@ app.post('/api/sessions', async (c) => {
     projectName?: string;
     fleet?: boolean;
     prompt?: string;
+    forkFrom?: unknown;
   };
+  if (body.forkFrom !== undefined) {
+    if (typeof body.forkFrom !== 'string' || !body.forkFrom.trim()) {
+      return c.json({ error: 'forkFrom must be a session file path' }, 400);
+    }
+    const stat = await fs.stat(body.forkFrom).catch(() => null);
+    if (!stat?.isFile()) {
+      return c.json({ error: `forkFrom is not an existing session file: ${body.forkFrom}` }, 400);
+    }
+  }
   const id = randomUUID();
   sessionManager.spawn(
     id,
@@ -257,6 +270,7 @@ app.post('/api/sessions', async (c) => {
       worktree: body.worktree,
       base: body.base,
       projectName: body.projectName,
+      forkFrom: body.forkFrom,
       env: body.fleet ? { KILD_FLEET: '1' } : undefined,
     },
     'cli',

--- a/engine/src/worker.fork.test.ts
+++ b/engine/src/worker.fork.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { SessionManager as PiSessionManager } from '@earendil-works/pi-coding-agent';
+
+// The worker's fork-spawn (KILD_FORK_SESSION) rests on one SDK guarantee:
+// SessionManager.forkFrom copies the source session's history into a brand-new
+// session file and NEVER writes the source — so a fork can be prompted freely
+// without polluting or corrupting the original. These tests pin that contract
+// (an explicit sessionDir keeps them out of the user's ~/.pi).
+
+let tmp: string;
+
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kild-fork-'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeSourceSession(): string {
+  const dir = fs.mkdtempSync(path.join(tmp, 'source-'));
+  const file = path.join(dir, '2026-07-24T10-00-00-000Z_source.jsonl');
+  const entries = [
+    {
+      type: 'session',
+      version: 3,
+      id: 'source-session',
+      timestamp: '2026-07-24T10:00:00.000Z',
+      cwd: '/original/project',
+    },
+    {
+      type: 'message',
+      id: 'e1',
+      parentId: null,
+      timestamp: '2026-07-24T10:00:01.000Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'the authoring history' }] },
+    },
+  ];
+  fs.writeFileSync(file, `${entries.map((e) => JSON.stringify(e)).join('\n')}\n`);
+  return file;
+}
+
+test('forkFrom creates a NEW session file carrying the source history', () => {
+  const source = writeSourceSession();
+  const targetCwd = fs.mkdtempSync(path.join(tmp, 'target-'));
+  const sessionDir = fs.mkdtempSync(path.join(tmp, 'sessions-'));
+
+  const forked = PiSessionManager.forkFrom(source, targetCwd, sessionDir);
+  const forkedFile = forked.getSessionFile() as string;
+
+  expect(forkedFile).toBeDefined();
+  expect(forkedFile).not.toBe(source);
+  expect(forked.getSessionId()).not.toBe('source-session');
+  // The copied history is in the fork, and its header points back to the source.
+  expect(fs.readFileSync(forkedFile, 'utf8')).toContain('the authoring history');
+  expect(forked.getHeader()?.parentSession).toBe(source);
+});
+
+test('the source session file is never written — even when the fork is appended to', () => {
+  const source = writeSourceSession();
+  const before = fs.readFileSync(source, 'utf8');
+  const sessionDir = fs.mkdtempSync(path.join(tmp, 'sessions-'));
+
+  const forked = PiSessionManager.forkFrom(
+    source,
+    fs.mkdtempSync(path.join(tmp, 'target-')),
+    sessionDir,
+  );
+  forked.appendMessage({
+    role: 'user',
+    content: [{ type: 'text', text: 'a question against the frozen snapshot' }],
+  });
+
+  expect(fs.readFileSync(source, 'utf8')).toBe(before); // byte-identical
+  expect(fs.readFileSync(forked.getSessionFile() as string, 'utf8')).toContain(
+    'a question against the frozen snapshot',
+  );
+});

--- a/engine/src/worker.ts
+++ b/engine/src/worker.ts
@@ -6,10 +6,11 @@ import {
   DefaultResourceLoader,
   getAgentDir,
   ModelRegistry,
+  SessionManager as PiSessionManager,
 } from '@earendil-works/pi-coding-agent';
 
 import { resolveAgentInstructions } from './kild/agents.ts';
-import { configuredModels, resolvePluginPaths } from './kild/config.ts';
+import { configuredMemoryDir, configuredModels, resolvePluginPaths } from './kild/config.ts';
 import { type RawAgentEvent, translate, type UiEvent } from './kild/events.ts';
 import { createFleetCloseRoomTool } from './kild/fleet/close-room-tool.ts';
 import { createOpenRoomTool } from './kild/fleet/open-room-tool.ts';
@@ -50,6 +51,7 @@ export async function runWorker(): Promise<never> {
   const isRoomLead = process.env.KILD_ROOM_LEAD === '1';
   const fleetEnabled = process.env.KILD_FLEET === '1';
   const skillsProfile = process.env.KILD_SKILLS_PROFILE || undefined;
+  const forkFrom = process.env.KILD_FORK_SESSION || undefined;
 
   const emit = (event: UiEvent) => process.stdout.write(`${JSON.stringify(event)}\n`);
   const pendingCommands = new Map<
@@ -140,6 +142,11 @@ export async function runWorker(): Promise<never> {
         : undefined;
     }
     await resourceLoader?.reload();
+    // Fork-spawn: seed this session with the full history of an existing pi session
+    // file (KILD_FORK_SESSION), frozen at fork time. `forkFrom` COPIES the source
+    // into a brand-new session file (same semantics as pi's own `--fork`), so the
+    // source is never written — two writers on one file are impossible.
+    const piSessionManager = forkFrom ? PiSessionManager.forkFrom(forkFrom, cwd) : undefined;
     ({ session } = await createAgentSession({
       model,
       authStorage,
@@ -147,6 +154,7 @@ export async function runWorker(): Promise<never> {
       cwd,
       customTools,
       resourceLoader,
+      sessionManager: piSessionManager,
     }));
   } catch (err) {
     emit({ kind: 'error', message: errText(err) });
@@ -196,9 +204,13 @@ export async function runWorker(): Promise<never> {
   const modelsSection =
     inRoom || fleetEnabled ? formatModelsSection(await configuredModels(cwd)) : '';
   // Persistent memory rides the first turn: fleet drivers get the operator's cross-project
-  // memory; every session gets the project's curated memory + direction (read from the
-  // MAIN checkout — the files are gitignored, so worktree checkouts never carry them).
-  const memorySections = [fleetEnabled ? fleetMemorySection() : '', projectMemorySection(cwd)]
+  // memory; every session gets the project's curated memory + direction, read from the
+  // resolved memory dir (config `memory.dir`, default `.kild/` — gitignored, so worktree
+  // checkouts never carry the default-dir files).
+  const memorySections = [
+    fleetEnabled ? fleetMemorySection() : '',
+    projectMemorySection(cwd, await configuredMemoryDir(cwd)),
+  ]
     .filter(Boolean)
     .join('\n\n');
   let sessionPrefix: string | null = [MECHANISM_PROMPT, modelsSection, memorySections]


### PR DESCRIPTION
Builds on #663 (project memory). Two vertical slices:

## memory.dir — configurable memory/artifact directory

The memory module hardcoded `<project>/.kild/` for LOG.md, MEMORY.md and direction.md. It is now config:

- `KildConfig` gains `memory.dir`, resolved by a new `configuredMemoryDir(cwd)` — merged like the other readers (project `.kild/config.json` wins over `$KILD_HOME/config.json`), `~` expands, a relative value resolves against the project cwd, default stays `.kild`. Always returns an absolute path; never throws.
- `memory.ts` functions take the resolved dir; the two call sites (room-manager close hook, worker memory injection) resolve it. `fleetMemorySection` is untouched.
- The synthesis charter and the `<project-memory>` labels name the ACTUAL paths — rendered project-relative when the dir is inside the project (the default still reads exactly `.kild/LOG.md` etc.), absolute otherwise — so the synthesis agent writes to the right place.
- The auto-written `.gitignore` only happens when the dir is inside the project; an external store (e.g. a user-home dir) gets none. kild never knows what convention the configured path follows — it is just a directory.

## fork-spawn — frozen-context sessions

`POST /api/sessions` accepts `forkFrom` (absolute pi session file path; rejected unless it is a string naming an existing file). Plumbed through `SpawnRequest` → `KILD_FORK_SESSION` → the worker, which builds its session with the SDK's `SessionManager.forkFrom(source, cwd)` — the exact mechanism pi's own `--fork` uses. The fork copies the full history into a brand-new session file (header `parentSession` points at the source, file created with `wx`); the source is never opened for writing, so interrogating a snapshot can never pollute or corrupt the original session. Also accepted by the fleet `engine-client.spawnSession` for future callers.

## Validation

- `bun run typecheck`, `bun run lint`, `bun test` — all green (168 tests).
- New tests: config merge/expansion/default cases for `configuredMemoryDir`; memory-dir resolution incl. external-dir-writes-no-gitignore and actual-path charters; `workerEnv` fork plumbing; a worker-level pin of the SDK fork contract (new file created, source byte-identical even after appending to the fork).