### PR TITLE
Observability completion: attention state, cost rollup, transcript endpoints

### DIFF
--- a/engine/src/kild/fleet/rooms-status.test.ts
+++ b/engine/src/kild/fleet/rooms-status.test.ts
@@ -182,6 +182,45 @@ test('compact view surfaces only OPEN decisions and omits the field when none', 
   expect(without).not.toHaveProperty('openDecisions');
 });
 
+test('per-participant attention + cost ride the compact view, with a room totals rollup', () => {
+  const compact = compactLiveRooms([
+    {
+      id: 'room-1',
+      name: 'ops',
+      participants: [
+        { name: 'worker', idle: true, posted: true, tokens: 3400, cost: 1.25 },
+        { name: 'reviewer', tokens: 600, cost: 0.25 },
+      ],
+      log: [],
+    },
+  ]);
+  expect(compact[0]?.participants).toEqual([
+    { name: 'worker', idle: true, posted: true, tokens: 3400, cost: 1.25 },
+    { name: 'reviewer', tokens: 600, cost: 0.25 },
+  ]);
+  expect(compact[0]?.totals).toEqual({ tokens: 4000, cost: 1.5 });
+});
+
+test('a room whose participants have no stats gets no totals key', () => {
+  const compact = compactLiveRooms([
+    { id: 'room-1', name: 'ops', participants: [{ name: 'worker' }], log: [] },
+  ]);
+  expect(compact[0]).not.toHaveProperty('totals');
+});
+
+test('server-computed totals on the live status are preferred over recomputing', () => {
+  const compact = compactLiveRooms([
+    {
+      id: 'room-1',
+      name: 'ops',
+      participants: [{ name: 'worker', tokens: 100, cost: 0.1 }],
+      log: [],
+      totals: { tokens: 4000, cost: 1.5 },
+    },
+  ]);
+  expect(compact[0]?.totals).toEqual({ tokens: 4000, cost: 1.5 });
+});
+
 test('compaction copies participant and post arrays without mutating the source room', () => {
   const rooms = [
     {

--- a/engine/src/kild/fleet/rooms-status.ts
+++ b/engine/src/kild/fleet/rooms-status.ts
@@ -1,5 +1,11 @@
 import { openDecisions, type RoomDecision } from '../room/room-decisions.ts';
-import type { LiveRoomStatus, ParticipantView, RoomMessage } from '../room/room-types.ts';
+import {
+  type LiveRoomStatus,
+  type ParticipantView,
+  type RoomCostTotals,
+  type RoomMessage,
+  roomCostTotals,
+} from '../room/room-types.ts';
 import type { WorkstreamGitStatus } from '../worktree-status.ts';
 
 /** The director's compact view of a workstream's git state: a summary, not the full
@@ -45,6 +51,9 @@ export interface CompactRoomStatus {
   /** Unresolved keyed decisions — each needs an operator call before this room can close.
    *  Absent when none are open (the normal case). */
   openDecisions?: RoomDecision[];
+  /** Room cost rollup (tokens + USD) summed over participants — absent until at least
+   *  one participant has reported `stats`. Per-participant figures ride `participants`. */
+  totals?: RoomCostTotals;
 }
 
 /** Full changed-file list → a count for the compact view. `path` and the rest ride
@@ -76,11 +85,13 @@ export function compactLiveRooms(liveRooms: LiveRoomStatus[]): CompactRoomStatus
   const collisions = computeCollisions(liveRooms);
   return liveRooms.map((room) => {
     const open = openDecisions(room);
+    const totals = room.totals ?? roomCostTotals(room.participants);
     return {
       id: room.id,
       name: room.name,
       participants: room.participants.map((participant) => ({ ...participant })),
       posts: room.log.slice(-2),
+      ...(totals ? { totals } : {}),
       ...(room.git ? { git: toCompactGit(room.git) } : {}),
       ...(collisions.has(room.id) ? { collidesWith: collisions.get(room.id) } : {}),
       ...(open.length > 0 ? { openDecisions: open } : {}),

--- a/engine/src/kild/room/room-manager.test.ts
+++ b/engine/src/kild/room/room-manager.test.ts
@@ -589,6 +589,65 @@ test('pi session handles survive into the archived snapshot', async () => {
   });
 });
 
+// ── attention state: idle/posted ride the observer views ─────────────────────────────
+
+test('idle and posted ride the live view — finished-and-waiting without parsing logs', async () => {
+  const { manager, callbacks, emitSession } = fixture();
+  await openRoom(manager, [{ name: 'worker' }, { name: 'reviewer' }]);
+
+  // worker finishes its turn having reported; reviewer is still working.
+  await callbacks.get('s-1')?.onMessage?.({ kind: 'message_out', text: 'done', to: ['human'] });
+  emitSession('s-1', { kind: 'agent_end' });
+
+  const [worker, reviewer] = manager.liveRooms()[0]?.participants ?? [];
+  expect(worker).toMatchObject({ name: 'worker', idle: true, posted: true });
+  expect(reviewer?.idle).toBeUndefined();
+  expect(reviewer?.posted).toBeUndefined();
+
+  // A delivered turn reactivates: idle/posted reset in the view too.
+  await manager.postFromHuman('room-1', 'one more thing', ['worker']);
+  expect(manager.liveRooms()[0]?.participants[0]).toMatchObject({
+    name: 'worker',
+    idle: false,
+    posted: false,
+  });
+});
+
+// ── cost rollup: stats events land on the participant and sum per room ───────────────
+
+test('stats events land on the participant and rooms carry a cost total', async () => {
+  const { manager, emitSession } = fixture();
+  await openRoom(manager, [{ name: 'worker' }, { name: 'reviewer' }]);
+
+  emitSession('s-1', { kind: 'stats', tokens: 1200, cost: 0.5, context_pct: 10 });
+  emitSession('s-1', { kind: 'stats', tokens: 3400, cost: 1.25, context_pct: 20 }); // latest wins
+  emitSession('s-2', { kind: 'stats', tokens: 600, cost: 0.25, context_pct: 5 });
+
+  const [worker, reviewer] = manager.liveRooms()[0]?.participants ?? [];
+  expect(worker).toMatchObject({ name: 'worker', tokens: 3400, cost: 1.25 });
+  expect(reviewer).toMatchObject({ name: 'reviewer', tokens: 600, cost: 0.25 });
+
+  const status = await manager.liveRoomsStatus();
+  expect(status[0]?.totals).toEqual({ tokens: 4000, cost: 1.5 });
+});
+
+test('a room with no stats yet carries no totals (no zero-noise)', async () => {
+  const { manager } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  const status = await manager.liveRoomsStatus();
+  expect(status[0]?.totals).toBeUndefined();
+});
+
+test('participant costs survive into the archived snapshot', async () => {
+  const { manager, emitSession } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await manager.postFromHuman('room-1', 'kick off'); // history so close archives it
+  emitSession('s-1', { kind: 'stats', tokens: 900, cost: 0.33, context_pct: null });
+  await manager.close('room-1');
+
+  expect(manager.archived()[0]?.participants[0]).toMatchObject({ tokens: 900, cost: 0.33 });
+});
+
 // ── memory hook: engine-written log on close, optional synthesis spawn ────────────────
 
 test('closing a room with history appends its engine-written entry to .kild/LOG.md', async () => {

--- a/engine/src/kild/room/room-manager.ts
+++ b/engine/src/kild/room/room-manager.ts
@@ -40,6 +40,7 @@ import {
   type RoomMessage,
   type RoomOutbound,
   type RoomParticipant,
+  roomCostTotals,
 } from './room-types.ts';
 
 /** Soft cap on room size — a cheap loop/scale guard in v1 (loop control is otherwise
@@ -130,9 +131,22 @@ export class RoomManager {
           provider?: string;
           id?: string;
           file?: string;
+          tokens?: number;
+          cost?: number;
         };
         if (event.kind === 'model' && event.provider && event.id) {
           located.participant.model = `${event.provider}/${event.id}`;
+        }
+        // Capture the latest cumulative cost snapshot (emitted at every turn end) so
+        // observers can rank rooms by spend without parsing transcripts. No persistNow:
+        // the next post's write-through snapshot — or close() — carries it to disk.
+        if (
+          event.kind === 'stats' &&
+          typeof event.tokens === 'number' &&
+          typeof event.cost === 'number'
+        ) {
+          located.participant.tokens = event.tokens;
+          located.participant.cost = event.cost;
         }
         // The pi session identity is the participant's durable terminal-resume handle;
         // persist it so archived rooms keep it too (there may be no later post to piggyback
@@ -262,6 +276,7 @@ export class RoomManager {
         state: room.state,
         log: room.log,
         decisions: room.decisions,
+        totals: roomCostTotals(room.participants),
         git: await workstreamGitStatus(
           room.worktree ? worktreePath(room.worktree) : room.cwd,
           room.base,

--- a/engine/src/kild/room/room-types.ts
+++ b/engine/src/kild/room/room-types.ts
@@ -37,14 +37,21 @@ export interface RoomParticipant {
   piSessionId?: string;
   /** Absolute pi session file path (resume works from any cwd). */
   piSessionFile?: string;
-  /** Runtime-only: true when the session has finished a turn and is waiting. Set on
-   *  `agent_end`, cleared when a new prompt is delivered. Dedups the idle failsafe to
-   *  one check per active→idle transition; never serialized. */
+  /** True when the session has finished a turn and is waiting. Set on `agent_end`,
+   *  cleared when a new prompt is delivered. Dedups the idle failsafe to one check per
+   *  active→idle transition, and rides {@link ParticipantView} so observers can rank
+   *  finished-and-waiting rooms without parsing logs. */
   idle?: boolean;
-  /** Runtime-only: true once this participant made an EXPLICIT post_message since its last
-   *  activation. If it goes idle with this still false, it finished without reporting — the
-   *  failsafe nudges it to post. Reset when a new turn is delivered; never serialized. */
+  /** True once this participant made an EXPLICIT post_message since its last activation.
+   *  If it goes idle with this still false, it finished without reporting — the failsafe
+   *  nudges it to post. Reset when a new turn is delivered. Rides {@link ParticipantView}
+   *  with `idle` (idle+posted = finished AND reported). */
   posted?: boolean;
+  /** Latest cumulative token count for this participant's session, captured from its
+   *  `stats` UiEvents (emitted at each turn end). */
+  tokens?: number;
+  /** Latest cumulative cost (USD) for this participant's session, from `stats` UiEvents. */
+  cost?: number;
 }
 
 /** A participant as surfaced to observers (room lists, status, archive) — identity plus
@@ -56,6 +63,14 @@ export interface ParticipantView {
   model?: string;
   piSessionId?: string;
   piSessionFile?: string;
+  /** Attention state: finished a turn and waiting for input (see {@link RoomParticipant.idle}). */
+  idle?: boolean;
+  /** Attention state: reported via an explicit delivered post this activation. */
+  posted?: boolean;
+  /** Latest cumulative session token count (from `stats` UiEvents). */
+  tokens?: number;
+  /** Latest cumulative session cost in USD (from `stats` UiEvents). */
+  cost?: number;
 }
 
 /** The one mapping from a live participant to its observer view — every list/status/
@@ -67,6 +82,29 @@ export function participantView(participant: RoomParticipant): ParticipantView {
     model: participant.model,
     piSessionId: participant.piSessionId,
     piSessionFile: participant.piSessionFile,
+    idle: participant.idle,
+    posted: participant.posted,
+    tokens: participant.tokens,
+    cost: participant.cost,
+  };
+}
+
+/** A room's cost rollup, summed over the participants that have reported `stats`. */
+export interface RoomCostTotals {
+  tokens: number;
+  cost: number;
+}
+
+/** Sum participant costs into a room total — undefined until at least one participant
+ *  has reported stats, so payloads without cost data stay clean of zero-noise. */
+export function roomCostTotals(
+  participants: Array<Pick<ParticipantView, 'tokens' | 'cost'>>,
+): RoomCostTotals | undefined {
+  const reported = participants.filter((p) => p.tokens !== undefined || p.cost !== undefined);
+  if (reported.length === 0) return undefined;
+  return {
+    tokens: reported.reduce((sum, p) => sum + (p.tokens ?? 0), 0),
+    cost: reported.reduce((sum, p) => sum + (p.cost ?? 0), 0),
   };
 }
 
@@ -170,6 +208,8 @@ export interface ArchivedRoom {
  *  live-only (never persisted); computed on demand when serving live-room status. */
 export interface LiveRoomStatus extends ArchivedRoom {
   git?: WorkstreamGitStatus;
+  /** Room cost rollup summed over participants — absent until stats have arrived. */
+  totals?: RoomCostTotals;
 }
 
 /** Typed room-domain result: every command either succeeds with a value or fails with

--- a/engine/src/kild/session-transcript.test.ts
+++ b/engine/src/kild/session-transcript.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  clampTranscriptTail,
+  DEFAULT_TRANSCRIPT_TAIL,
+  MAX_TRANSCRIPT_TAIL,
+  parseSessionTranscript,
+  readSessionTranscript,
+} from './session-transcript.ts';
+
+// Synthetic pi session JSONL, mirroring the real v3 shapes observed under
+// ~/.pi/agent/sessions/: session header, model/thinking bookkeeping, then message
+// entries (user/assistant/toolResult) whose content blocks are text/thinking/toolCall.
+const line = (value: unknown) => JSON.stringify(value);
+const message = (role: string, content: unknown) =>
+  line({ type: 'message', message: { role, content } });
+
+const FIXTURE_LINES = [
+  line({ type: 'session', version: 3, id: 'sess-1', timestamp: 't', cwd: '/tmp/ws' }),
+  line({ type: 'model_change', id: 'a', parentId: null, provider: 'minimax', modelId: 'M3' }),
+  line({ type: 'thinking_level_change', id: 'b', thinkingLevel: 'medium' }),
+  message('user', [{ type: 'text', text: 'fix the bug' }]),
+  message('assistant', [
+    { type: 'thinking', thinking: 'internal reasoning — not transcript text' },
+    { type: 'text', text: 'Looking at the file.' },
+    { type: 'toolCall', id: 'c1', name: 'read', arguments: { path: 'a.ts' } },
+  ]),
+  message('toolResult', [{ type: 'text', text: 'contents of a.ts' }]),
+  message('assistant', [{ type: 'thinking', thinking: 'thinking-only entry' }]),
+  message('assistant', [{ type: 'text', text: 'Done — fixed.' }]),
+  line({ type: 'future_entry_kind', payload: true }),
+  message('supervisor', [{ type: 'text', text: 'unknown role' }]),
+  'this line is not JSON at all',
+  '{"type":"message","message":{"role":"assistant","content":[{"type":"te', // partial trailing write
+];
+const FIXTURE = FIXTURE_LINES.join('\n');
+
+test('parses the known message shapes into compact entries and skips everything else', () => {
+  const { entries, total } = parseSessionTranscript(FIXTURE);
+  expect(total).toBe(4);
+  expect(entries).toEqual([
+    { role: 'user', text: 'fix the bug' },
+    { role: 'assistant', text: 'Looking at the file.', toolCalls: ['read'] },
+    { role: 'tool', text: 'contents of a.ts' },
+    { role: 'assistant', text: 'Done — fixed.' },
+  ]);
+});
+
+test('tail keeps only the most recent entries but reports the full total', () => {
+  const { entries, total } = parseSessionTranscript(FIXTURE, 2);
+  expect(total).toBe(4);
+  expect(entries.map((e) => e.text)).toEqual(['contents of a.ts', 'Done — fixed.']);
+});
+
+test('a string-content message (legacy/loose shape) still yields its text', () => {
+  const { entries } = parseSessionTranscript(message('user', 'plain string content'));
+  expect(entries).toEqual([{ role: 'user', text: 'plain string content' }]);
+});
+
+test('a toolCall-only assistant entry survives with empty text', () => {
+  const { entries } = parseSessionTranscript(
+    message('assistant', [{ type: 'toolCall', id: 'c9', name: 'bash', arguments: {} }]),
+  );
+  expect(entries).toEqual([{ role: 'assistant', text: '', toolCalls: ['bash'] }]);
+});
+
+test('oversized entry text is truncated to bound the response size', () => {
+  const { entries } = parseSessionTranscript(
+    message('toolResult', [{ type: 'text', text: 'x'.repeat(10_000) }]),
+  );
+  expect(entries[0]?.text.length).toBeLessThan(4_100);
+  expect(entries[0]?.text.endsWith('… (truncated)')).toBe(true);
+});
+
+test('garbage input never throws — empty and hostile lines produce an empty transcript', () => {
+  expect(parseSessionTranscript('')).toEqual({ entries: [], total: 0 });
+  expect(parseSessionTranscript('null\n42\n"str"\n[1,2]\n{"type":"message"}\n{}')).toEqual({
+    entries: [],
+    total: 0,
+  });
+});
+
+test('clampTranscriptTail: default for absent/invalid, clamped to [1, MAX]', () => {
+  expect(clampTranscriptTail()).toBe(DEFAULT_TRANSCRIPT_TAIL);
+  expect(clampTranscriptTail(Number.NaN)).toBe(DEFAULT_TRANSCRIPT_TAIL);
+  expect(clampTranscriptTail(0)).toBe(1);
+  expect(clampTranscriptTail(7)).toBe(7);
+  expect(clampTranscriptTail(1_000_000)).toBe(MAX_TRANSCRIPT_TAIL);
+});
+
+// ── file-backed read (the endpoint path) ────────────────────────────────────────────
+
+let tmp: string;
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kild-transcript-'));
+});
+afterAll(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('readSessionTranscript reads and parses a fixture file with a tail', async () => {
+  const file = path.join(tmp, 'session.jsonl');
+  fs.writeFileSync(file, FIXTURE);
+  const { entries, total } = await readSessionTranscript(file, 1);
+  expect(total).toBe(4);
+  expect(entries).toEqual([{ role: 'assistant', text: 'Done — fixed.' }]);
+});
+
+test('readSessionTranscript throws on a missing file (the caller maps it to 404)', async () => {
+  expect(readSessionTranscript(path.join(tmp, 'gone.jsonl'))).rejects.toThrow();
+});

--- a/engine/src/kild/session-transcript.ts
+++ b/engine/src/kild/session-transcript.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises';
+
+/**
+ * Compact, defensive reader for pi session JSONL files (`~/.pi/agent/sessions/…`) —
+ * the transcript half of observability: any participant/session with a persisted
+ * `piSessionFile` can be read back as a compact conversation, live or archived.
+ *
+ * The file format is pi's (session header + `message` entries with role
+ * user/assistant/toolResult; content blocks of type text/thinking/toolCall). It is
+ * an EXTERNAL shape owned by pi, so parsing is best-effort by design: unknown entry
+ * types, unknown content kinds, malformed JSON, and partial trailing lines are all
+ * skipped — a transcript read must never crash on a file pi is still appending to.
+ */
+
+/** One compact transcript entry: who spoke, what they said, which tools they called. */
+export interface TranscriptEntry {
+  role: 'user' | 'assistant' | 'tool';
+  text: string;
+  /** Tool names invoked by an assistant entry (arguments deliberately dropped — compact). */
+  toolCalls?: string[];
+}
+
+export interface SessionTranscript {
+  entries: TranscriptEntry[];
+  /** Total parseable transcript entries in the file, before the tail cut. */
+  total: number;
+}
+
+/** Sane default window: the recent conversation, not the whole session. */
+export const DEFAULT_TRANSCRIPT_TAIL = 50;
+/** Hard cap on requested tail — bounds the response size no matter what a client asks. */
+export const MAX_TRANSCRIPT_TAIL = 200;
+/** Per-entry text cap — one giant tool result must not blow up the payload. */
+const MAX_ENTRY_TEXT = 4_000;
+
+function truncate(text: string): string {
+  return text.length > MAX_ENTRY_TEXT ? `${text.slice(0, MAX_ENTRY_TEXT)}… (truncated)` : text;
+}
+
+/** Clamp a requested tail to [1, MAX]; undefined/invalid → the default. */
+export function clampTranscriptTail(tail?: number): number {
+  if (tail === undefined || !Number.isFinite(tail)) return DEFAULT_TRANSCRIPT_TAIL;
+  return Math.min(Math.max(Math.floor(tail), 1), MAX_TRANSCRIPT_TAIL);
+}
+
+/** One JSONL line → a compact entry, or null for anything unknown/irrelevant. */
+function toEntry(line: string): TranscriptEntry | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null; // malformed or partial line (pi may still be writing) — skip
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const record = parsed as { type?: unknown; message?: unknown };
+  if (record.type !== 'message') return null; // session header, model_change, … — skip
+  if (typeof record.message !== 'object' || record.message === null) return null;
+  const message = record.message as { role?: unknown; content?: unknown };
+
+  const role =
+    message.role === 'user' || message.role === 'assistant'
+      ? message.role
+      : message.role === 'toolResult'
+        ? 'tool'
+        : null;
+  if (!role) return null; // unknown role — skip
+
+  const texts: string[] = [];
+  const toolCalls: string[] = [];
+  if (typeof message.content === 'string') {
+    texts.push(message.content);
+  } else if (Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (typeof block !== 'object' || block === null) continue;
+      const { type, text, name } = block as { type?: unknown; text?: unknown; name?: unknown };
+      if (type === 'text' && typeof text === 'string') texts.push(text);
+      else if (type === 'toolCall' && typeof name === 'string') toolCalls.push(name);
+      // thinking and any future block kinds: not transcript text — skip
+    }
+  }
+
+  const text = truncate(texts.join('\n').trim());
+  if (!text && toolCalls.length === 0) return null; // e.g. a thinking-only entry
+  return { role, text, ...(toolCalls.length > 0 ? { toolCalls } : {}) };
+}
+
+/** Parse raw JSONL into a compact transcript, keeping only the last `tail` entries. */
+export function parseSessionTranscript(jsonl: string, tail?: number): SessionTranscript {
+  const entries: TranscriptEntry[] = [];
+  for (const raw of jsonl.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const entry = toEntry(line);
+    if (entry) entries.push(entry);
+  }
+  return { entries: entries.slice(-clampTranscriptTail(tail)), total: entries.length };
+}
+
+/** Read + parse a pi session file. Throws only on the read itself (missing/unreadable
+ *  file) — the caller maps that to its transport error; content problems never throw. */
+export async function readSessionTranscript(
+  file: string,
+  tail?: number,
+): Promise<SessionTranscript> {
+  return parseSessionTranscript(await fs.readFile(file, 'utf8'), tail);
+}

--- a/engine/src/server.ts
+++ b/engine/src/server.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
 import { createBunWebSocket } from 'hono/bun';
 import { cors } from 'hono/cors';
 
@@ -23,6 +23,7 @@ import {
 } from './kild/room/rest-room-attribution.ts';
 import { roomManager } from './kild/room/room-manager.ts';
 import type { CommandResult, ParticipantSpec } from './kild/room/room-types.ts';
+import { readSessionTranscript } from './kild/session-transcript.ts';
 import { sessionManager } from './kild/sessions.ts';
 import {
   assertSafeBranch,
@@ -230,6 +231,52 @@ app.post('/api/open-url', async (c) => {
   } catch (err) {
     return c.json({ error: String(err instanceof Error ? err.message : err) }, 400);
   }
+});
+
+// ── Transcripts ───────────────────────────────────────────────────────────────
+// Compact conversation readback from a pi session file (see session-transcript.ts).
+// `tail` bounds the entry count; invalid values are a client error, not a default.
+async function serveTranscript(
+  c: Context,
+  piSessionFile: string | undefined,
+  who: string,
+): Promise<Response> {
+  if (!piSessionFile) {
+    return c.json({ error: `${who} has no pi session file (yet)` }, 404);
+  }
+  const rawTail = c.req.query('tail');
+  const tail = rawTail === undefined ? undefined : Number(rawTail);
+  if (tail !== undefined && (!Number.isInteger(tail) || tail < 1)) {
+    return c.json({ error: 'tail must be a positive integer' }, 400);
+  }
+  try {
+    return c.json(await readSessionTranscript(piSessionFile, tail));
+  } catch (err) {
+    // The handle is persisted but the file may be gone (pi's dir cleaned up).
+    return c.json({ error: `transcript unreadable: ${errText(err)}` }, 404);
+  }
+}
+
+// A room participant's transcript — works for LIVE and ARCHIVED rooms alike: the
+// piSessionFile handle persists in $KILD_HOME/rooms/<id>.json past the session's death.
+app.get('/api/rooms/:id/participants/:name/transcript', async (c) => {
+  const id = c.req.param('id');
+  const name = c.req.param('name');
+  const room =
+    roomManager.liveRooms().find((r) => r.id === id) ??
+    roomManager.archived().find((r) => r.id === id);
+  if (!room) return c.json({ error: `no such room: ${id}` }, 404);
+  const participant = room.participants.find((p) => p.name === name);
+  if (!participant) return c.json({ error: `no such participant: @${name}` }, 404);
+  return serveTranscript(c, participant.piSessionFile, `participant @${name}`);
+});
+
+// A live session's transcript (fleet drivers, one-shot runs) via SessionInfo.
+app.get('/api/sessions/:id/transcript', async (c) => {
+  const id = c.req.param('id');
+  const info = sessionManager.list().find((s) => s.id === id);
+  if (!info) return c.json({ error: `no such session: ${id}` }, 404);
+  return serveTranscript(c, info.piSessionFile, `session ${id}`);
 });
 
 // ── Sessions ──────────────────────────────────────────────────────────────────

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -110,7 +110,9 @@ interface LiveRoom {
     model?: string;
     piSessionId?: string;
     piSessionFile?: string;
+    idle?: boolean;
   }>;
+  totals?: { tokens: number; cost: number };
   log: Array<{
     id?: string;
     from: string;
@@ -138,8 +140,16 @@ function gitLine(g?: GitStatus): string {
 
 function participantLine(room: LiveRoom): string {
   return room.participants
-    .map((p) => (p.model ? `${p.name}:${p.model}` : p.name))
+    .map((p) => `${p.model ? `${p.name}:${p.model}` : p.name}${p.idle ? ' (idle)' : ''}`)
     .join(', ');
+}
+
+/** Room cost rollup suffix, e.g. ` · $0.43 (128k tok)` — empty until stats arrive. */
+function costLine(room: LiveRoom): string {
+  const t = room.totals;
+  if (!t) return '';
+  const tokens = t.tokens >= 1000 ? `${Math.round(t.tokens / 1000)}k` : `${t.tokens}`;
+  return ` · $${t.cost.toFixed(2)} (${tokens} tok)`;
 }
 
 /** Terminal-resume handles for a room's agents — any agent session can be reopened in a
@@ -516,7 +526,7 @@ export default function (pi: PiExtensionAPI) {
       const lines = rooms.map((r) => {
         const last = r.log.filter((m) => !m.system).at(-1);
         const lastLine = last ? `\n    last: ${last.from} → [${last.to.join(', ')}]: ${last.text.replace(/\s+/g, ' ').slice(0, 120)}` : '';
-        return `${r.id}\n    ${r.name} [${participantLine(r)}]${gitLine(r.git)}${openDecisionsLine(r)}${resumeLines(r)}${lastLine}`;
+        return `${r.id}\n    ${r.name} [${participantLine(r)}]${gitLine(r.git)}${costLine(r)}${openDecisionsLine(r)}${resumeLines(r)}${lastLine}`;
       });
       return { content: [{ type: 'text', text: truncate(lines.join('\n')) }], details: { count: rooms.length } };
     },


### PR DESCRIPTION
Completes the observability slice: attention state and cost ride every room payload, and any agent's conversation can be read back over REST — live or archived — without parsing logs or session files by hand.

## What changed

**1. Attention state is serialized.** `RoomParticipant.idle` / `.posted` were runtime-only; they now ride `ParticipantView` through the single `participantView()` mapper, so summaries, `liveWithLogs`, `liveRoomsStatus`, the archived snapshot, and the fleet compact view all carry them at once. Clients can rank finished-and-waiting rooms directly (`idle: true, posted: true` = finished AND reported).

**2. Per-room cost rollup.** The RoomManager captures each session's `stats` UiEvent (same pattern as the existing `model` / `pi_session` captures) onto the participant, and live payloads sum a room `totals`. Omitted until at least one participant has reported, so payloads stay free of zero-noise.

```json
{
  "participants": [
    { "name": "worker", "model": "minimax/MiniMax-M3", "idle": true, "posted": true, "tokens": 3400, "cost": 1.25 },
    { "name": "reviewer", "tokens": 600, "cost": 0.25 }
  ],
  "totals": { "tokens": 4000, "cost": 1.5 }
}
```

**3. Transcript endpoints.** Compact conversation readback from the pi session JSONL:

- `GET /api/rooms/:id/participants/:name/transcript?tail=N` — live AND archived rooms (`piSessionFile` persists in `$KILD_HOME/rooms/<id>.json` past the session's death)
- `GET /api/sessions/:id/transcript` — live sessions via `SessionInfo.piSessionFile`

Parsing lives in `engine/src/kild/session-transcript.ts` and is defensive by design — the JSONL shape is pi's, so unknown entry kinds, unknown content blocks, malformed JSON, and partial trailing lines are skipped, never thrown on. Tail defaults to 50 (cap 200); per-entry text is truncated at 4k chars to bound the response.

```json
{
  "entries": [
    { "role": "user", "text": "[#triage-1863] @human: Begin the assigned read-only triage now..." },
    { "role": "assistant", "text": "", "toolCalls": ["post_message"] },
    { "role": "tool", "text": "Posted to the room." },
    { "role": "assistant", "text": "Posted the completed read-only triage result to the room with evidence..." }
  ],
  "total": 36
}
```

(Real output from a real session file under `~/.pi/agent/sessions/`, `tail=4`.)

**4. pi extension render.** `kild_rooms` marks idle participants — `worker:minimax/MiniMax-M3 (idle)` — and appends a room cost suffix after the git summary: `· $1.50 (4k tok)`. Render-only; the fields come from the engine.

## Gates

- `bun test`: 184 pass, 0 fail (16 new tests: attention state, cost capture + totals + archive survival, transcript parsing against a synthetic fixture, compact-view rollup)
- `bun run typecheck`: clean
- `bun run lint`: clean
- Parser additionally smoke-tested against a real pi v3 session file (36 entries, shapes verified before writing the parser)

## Notes

- Costs are the session-cumulative snapshot from pi's `getSessionStats()` (latest wins), not a delta stream.
- Stats capture deliberately skips `persistNow()` — the next post's write-through snapshot, or `close()`, carries it to disk; no per-turn disk writes.
- Archived rooms written before this change simply lack the new fields; all of them are optional.
