### PR TITLE
feat(engine): git review intelligence for live rooms

### DIFF
--- a/engine/src/kild/git-review.test.ts
+++ b/engine/src/kild/git-review.test.ts
@@ -1,0 +1,296 @@
+import { afterAll, expect, test } from 'bun:test';
+import { execFile as execFileCb } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import {
+  DIFF_CAP,
+  parseCommitLog,
+  parseNameStatusZ,
+  parseNumstatZ,
+  parsePorcelainZ,
+  reviewCommits,
+  reviewDiff,
+  reviewFiles,
+} from './git-review.ts';
+
+const execFile = promisify(execFileCb);
+
+const tmpDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function mkTmp(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function git(dir: string, args: string[]): Promise<void> {
+  await execFile('git', ['-C', dir, ...args]);
+}
+
+// Commit with a fixed identity so the temp repo doesn't depend on the host's git config.
+async function commit(dir: string, message: string): Promise<void> {
+  await execFile('git', [
+    '-C',
+    dir,
+    '-c',
+    'user.email=t@t',
+    '-c',
+    'user.name=t',
+    'commit',
+    '-m',
+    message,
+  ]);
+}
+
+// A fresh repo on `main` with one committed file.
+async function initRepo(): Promise<string> {
+  const dir = mkTmp('kild-git-review-');
+  await git(dir, ['init', '-b', 'main']);
+  fs.writeFileSync(path.join(dir, 'README.md'), 'hello\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'initial');
+  return dir;
+}
+
+// ── reviewCommits ─────────────────────────────────────────────────────────────
+
+test('commits vs base come newest-first with per-commit stats', async () => {
+  const dir = await initRepo();
+  await git(dir, ['checkout', '-b', 'feature']);
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'one\ntwo\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'add a');
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'one\n');
+  fs.writeFileSync(path.join(dir, 'b.txt'), 'b\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'trim a, add b');
+
+  const result = await reviewCommits(dir, 'main');
+
+  expect(result.error).toBeUndefined();
+  expect(result.base).toBe('main');
+  expect(result.commits).toHaveLength(2);
+  const [second, first] = result.commits;
+  expect(second?.subject).toBe('trim a, add b');
+  expect(second?.author).toBe('t');
+  expect(second?.sha).toMatch(/^[0-9a-f]{40}$/);
+  expect(second?.ts).toBeGreaterThan(1_600_000_000_000); // epoch millis, not seconds
+  expect(second?.filesChanged).toBe(2);
+  expect(second?.additions).toBe(1); // b.txt line
+  expect(second?.deletions).toBe(1); // trimmed a.txt line
+  expect(first?.subject).toBe('add a');
+  expect(first?.filesChanged).toBe(1);
+  expect(first?.additions).toBe(2);
+  expect(first?.deletions).toBe(0);
+});
+
+test('no commits ahead of base yields an empty list, no error', async () => {
+  const dir = await initRepo();
+  const result = await reviewCommits(dir, 'main');
+  expect(result.error).toBeUndefined();
+  expect(result.commits).toEqual([]);
+});
+
+test('commits: a missing base ref is an error object, not a crash', async () => {
+  const dir = await initRepo();
+  const result = await reviewCommits(dir, 'does-not-exist');
+  expect(result.error).toBe('base ref not found: does-not-exist');
+  expect(result.commits).toEqual([]);
+});
+
+test('commits: a non-git directory is an error object, not a crash', async () => {
+  const dir = mkTmp('kild-git-review-nogit-');
+  const result = await reviewCommits(dir, 'main');
+  expect(result.error).toBeDefined();
+  expect(result.commits).toEqual([]);
+});
+
+// ── reviewFiles ───────────────────────────────────────────────────────────────
+
+test('files combine committed, uncommitted, and untracked changes vs base', async () => {
+  const dir = await initRepo();
+  await git(dir, ['checkout', '-b', 'feature']);
+  fs.writeFileSync(path.join(dir, 'committed.txt'), 'one\ntwo\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'add committed');
+  fs.writeFileSync(path.join(dir, 'README.md'), 'hello\nedited\n'); // uncommitted edit
+  fs.writeFileSync(path.join(dir, 'untracked.txt'), 'u1\nu2\nu3\n'); // never added
+
+  const result = await reviewFiles(dir, 'main');
+
+  expect(result.error).toBeUndefined();
+  const byPath = new Map(result.files.map((file) => [file.path, file]));
+  expect(byPath.get('committed.txt')).toEqual({
+    path: 'committed.txt',
+    additions: 2,
+    deletions: 0,
+    status: 'added',
+    uncommitted: false,
+  });
+  expect(byPath.get('README.md')).toEqual({
+    path: 'README.md',
+    additions: 1,
+    deletions: 0,
+    status: 'modified',
+    uncommitted: true,
+  });
+  expect(byPath.get('untracked.txt')).toEqual({
+    path: 'untracked.txt',
+    additions: 3,
+    deletions: 0,
+    status: 'added',
+    uncommitted: true,
+  });
+});
+
+test('files report deletions and renames with the pre-rename path', async () => {
+  const dir = await initRepo();
+  fs.writeFileSync(path.join(dir, 'gone.txt'), 'bye\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'add gone');
+  await git(dir, ['checkout', '-b', 'feature']);
+  await git(dir, ['rm', '-q', 'gone.txt']);
+  await git(dir, ['mv', 'README.md', 'RENAMED.md']);
+  await commit(dir, 'delete + rename');
+
+  const result = await reviewFiles(dir, 'main');
+
+  expect(result.error).toBeUndefined();
+  const byPath = new Map(result.files.map((file) => [file.path, file]));
+  expect(byPath.get('gone.txt')).toMatchObject({ status: 'deleted', deletions: 1 });
+  expect(byPath.get('RENAMED.md')).toMatchObject({
+    status: 'renamed',
+    renamedFrom: 'README.md',
+  });
+});
+
+test("files never include the base's own advances (merge-base semantics)", async () => {
+  const dir = await initRepo();
+  await git(dir, ['checkout', '-b', 'feature']);
+  fs.writeFileSync(path.join(dir, 'mine.txt'), 'mine\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'mine');
+  // Advance main independently — that change is NOT this workstream's work.
+  await git(dir, ['checkout', 'main']);
+  fs.writeFileSync(path.join(dir, 'theirs.txt'), 'theirs\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'theirs');
+  await git(dir, ['checkout', 'feature']);
+
+  const result = await reviewFiles(dir, 'main');
+
+  expect(result.error).toBeUndefined();
+  expect(result.files.map((file) => file.path)).toEqual(['mine.txt']);
+});
+
+test('files: a missing base ref is an error object, not a crash', async () => {
+  const dir = await initRepo();
+  const result = await reviewFiles(dir, 'does-not-exist');
+  expect(result.error).toBe('base ref not found: does-not-exist');
+  expect(result.files).toEqual([]);
+});
+
+// ── reviewDiff ────────────────────────────────────────────────────────────────
+
+test('diff returns one unified patch covering committed + working-tree changes', async () => {
+  const dir = await initRepo();
+  await git(dir, ['checkout', '-b', 'feature']);
+  fs.writeFileSync(path.join(dir, 'README.md'), 'hello\ncommitted\n');
+  await git(dir, ['add', '.']);
+  await commit(dir, 'committed line');
+  fs.writeFileSync(path.join(dir, 'README.md'), 'hello\ncommitted\nuncommitted\n');
+
+  const result = await reviewDiff(dir, 'main', 'README.md');
+
+  expect(result.error).toBeUndefined();
+  expect(result.truncated).toBe(false);
+  expect(result.patch).toContain('diff --git');
+  expect(result.patch).toContain('+committed');
+  expect(result.patch).toContain('+uncommitted');
+});
+
+test('diff covers an untracked file via no-index', async () => {
+  const dir = await initRepo();
+  fs.writeFileSync(path.join(dir, 'fresh.txt'), 'brand new\n');
+
+  const result = await reviewDiff(dir, 'main', 'fresh.txt');
+
+  expect(result.error).toBeUndefined();
+  expect(result.patch).toContain('+brand new');
+});
+
+test('diff refuses a path git did not report (traversal guard)', async () => {
+  const dir = await initRepo();
+  for (const evil of ['../../etc/passwd', '/etc/passwd', 'nope.txt']) {
+    const result = await reviewDiff(dir, 'main', evil);
+    expect(result.unknownPath).toBe(true);
+    expect(result.error).toContain('not reported by git');
+    expect(result.patch).toBe('');
+  }
+});
+
+test('diff larger than the cap is truncated and flagged', async () => {
+  const dir = await initRepo();
+  fs.writeFileSync(path.join(dir, 'big.txt'), 'x-line-of-payload\n'.repeat(20_000)); // ~360 KB
+
+  const result = await reviewDiff(dir, 'main', 'big.txt');
+
+  expect(result.error).toBeUndefined();
+  expect(result.truncated).toBe(true);
+  expect(result.patch.length).toBe(DIFF_CAP);
+});
+
+// ── pure parsers ──────────────────────────────────────────────────────────────
+
+test('parseCommitLog handles binary numstat entries and empty commits', () => {
+  const stdout =
+    '\x1eaaa\x1fbinary drop\x1falice\x1f1700000000\n\n-\t-\timage.png\n5\t0\tcode.ts\n' +
+    '\x1ebbb\x1fempty commit\x1fbob\x1f1700000100\n';
+  const commits = parseCommitLog(stdout);
+  expect(commits).toHaveLength(2);
+  expect(commits[0]).toEqual({
+    sha: 'aaa',
+    subject: 'binary drop',
+    author: 'alice',
+    ts: 1_700_000_000_000,
+    filesChanged: 2,
+    additions: 5,
+    deletions: 0,
+  });
+  expect(commits[1]).toMatchObject({ sha: 'bbb', filesChanged: 0, additions: 0, deletions: 0 });
+});
+
+test('parseNumstatZ decodes plain, binary, and rename entries', () => {
+  const stdout = '3\t1\tplain.ts\0-\t-\tbin.png\x005\t0\t\0old.ts\0new.ts\0';
+  expect(parseNumstatZ(stdout)).toEqual([
+    { path: 'plain.ts', additions: 3, deletions: 1 },
+    { path: 'bin.png', additions: 0, deletions: 0 },
+    { path: 'new.ts', additions: 5, deletions: 0 },
+  ]);
+});
+
+test('parseNameStatusZ decodes add/modify/delete/rename', () => {
+  const stdout = 'A\0new.ts\0M\0mod.ts\0D\0gone.ts\0R100\0old.ts\0moved.ts\0';
+  expect(parseNameStatusZ(stdout)).toEqual([
+    { path: 'new.ts', status: 'added' },
+    { path: 'mod.ts', status: 'modified' },
+    { path: 'gone.ts', status: 'deleted' },
+    { path: 'moved.ts', status: 'renamed', renamedFrom: 'old.ts' },
+  ]);
+});
+
+test('parsePorcelainZ separates untracked from tracked changes and skips rename origins', () => {
+  const stdout = ' M edited.ts\0?? fresh.ts\0R  renamed.ts\0orig.ts\0';
+  const { uncommitted, untracked } = parsePorcelainZ(stdout);
+  expect(untracked).toEqual(['fresh.ts']);
+  expect(uncommitted.has('edited.ts')).toBe(true);
+  expect(uncommitted.has('renamed.ts')).toBe(true);
+  expect(uncommitted.has('orig.ts')).toBe(false);
+});

--- a/engine/src/kild/git-review.ts
+++ b/engine/src/kild/git-review.ts
@@ -1,0 +1,401 @@
+import { execFile as execFileCb } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { resolveDefaultBase } from './worktree-status.ts';
+
+/**
+ * Review intelligence — the git drill-down behind a review surface. Where
+ * worktree-status answers "how far along is this workstream?" (summary), this module
+ * answers "what exactly changed?": the commits vs base, per-file diff stats
+ * (committed + uncommitted), and one file's unified patch.
+ *
+ * Same contract as worktree-status: execFile (no shell — `dir`/`base` may originate
+ * from an LLM-driven caller, so shell interpolation would be RCE), and every git
+ * failure is captured in `error`, NEVER thrown — a review probe must not be able to
+ * crash its caller.
+ */
+const execFile = promisify(execFileCb);
+
+const errText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/** Diff endpoint payload cap (~200 KB of patch text) — a review surface wants the
+ *  patch, not a memory bomb; past this the result is truncated and flagged. */
+export const DIFF_CAP = 200 * 1024;
+
+/** Headroom for raw git output before our own cap applies (execFile default is 1 MB,
+ *  which a real diff easily exceeds). */
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+/** One commit on the workstream branch that base doesn't have. `ts` is epoch millis
+ *  (matching `RoomMessage.ts`). */
+export interface ReviewCommit {
+  sha: string;
+  subject: string;
+  author: string;
+  ts: number;
+  filesChanged: number;
+  additions: number;
+  deletions: number;
+}
+
+export type ReviewFileStatus = 'added' | 'modified' | 'deleted' | 'renamed';
+
+/** Per-file diff stats vs base — committed and working-tree changes combined.
+ *  `uncommitted` marks files with working-tree/index changes not yet committed. */
+export interface ReviewFile {
+  path: string;
+  additions: number;
+  deletions: number;
+  status: ReviewFileStatus;
+  uncommitted: boolean;
+  /** For `renamed`: the pre-rename path. */
+  renamedFrom?: string;
+}
+
+export interface ReviewCommitsResult {
+  base: string;
+  commits: ReviewCommit[];
+  error?: string; // any git failure captured here, NEVER thrown
+}
+
+export interface ReviewFilesResult {
+  base: string;
+  files: ReviewFile[];
+  error?: string; // any git failure captured here, NEVER thrown
+}
+
+export interface ReviewDiffResult {
+  base: string;
+  path: string;
+  patch: string;
+  truncated: boolean;
+  error?: string; // any git failure captured here, NEVER thrown
+  /** Set when `path` is not a file git itself reported as changed — the traversal
+   *  guard; the HTTP layer maps it to a 404. */
+  unknownPath?: boolean;
+}
+
+type GitResult = { ok: true; stdout: string } | { ok: false; error: string };
+
+/** Run a git command under `dir`, capturing failure as data instead of throwing. */
+async function runGit(dir: string, args: string[]): Promise<GitResult> {
+  try {
+    const { stdout } = await execFile('git', ['-C', dir, ...args], { maxBuffer: MAX_BUFFER });
+    return { ok: true, stdout };
+  } catch (err) {
+    return { ok: false, error: errText(err) };
+  }
+}
+
+/** HEAD and the base ref must both resolve before any comparison is meaningful.
+ *  Returns the error string (worktree-status wording), or undefined when fine. */
+async function verifyRepoAndBase(dir: string, base: string): Promise<string | undefined> {
+  const head = await runGit(dir, ['rev-parse', '--verify', '--quiet', 'HEAD^{commit}']);
+  if (!head.ok) return head.error; // not a git repo, or no commits yet
+  const baseExists = await runGit(dir, ['rev-parse', '--verify', '--quiet', `${base}^{commit}`]);
+  if (!baseExists.ok) return `base ref not found: ${base}`;
+  return undefined;
+}
+
+// ── Pure parsers (exported for unit tests) ────────────────────────────────────
+
+// git log --format uses these separators so subjects with tabs/newlines can't break
+// parsing: \x1e starts each commit record, \x1f separates header fields.
+const RECORD_SEP = '\x1e';
+const FIELD_SEP = '\x1f';
+const LOG_FORMAT = `${RECORD_SEP}%H${FIELD_SEP}%s${FIELD_SEP}%an${FIELD_SEP}%at`;
+
+/** Parse `git log --numstat --format=<LOG_FORMAT>` output: one record per commit —
+ *  a header line, then numstat lines (`adds\tdels\tpath`; binary files show `-`). */
+export function parseCommitLog(stdout: string): ReviewCommit[] {
+  const commits: ReviewCommit[] = [];
+  for (const record of stdout.split(RECORD_SEP)) {
+    if (!record.trim()) continue;
+    const lines = record.split('\n');
+    const [sha, subject, author, at] = (lines[0] ?? '').split(FIELD_SEP);
+    if (!sha) continue;
+    const commit: ReviewCommit = {
+      sha,
+      subject: subject ?? '',
+      author: author ?? '',
+      ts: (Number.parseInt(at ?? '', 10) || 0) * 1000,
+      filesChanged: 0,
+      additions: 0,
+      deletions: 0,
+    };
+    for (const line of lines.slice(1)) {
+      const stat = /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line);
+      if (!stat) continue;
+      commit.filesChanged += 1;
+      if (stat[1] !== '-') commit.additions += Number.parseInt(stat[1] as string, 10);
+      if (stat[2] !== '-') commit.deletions += Number.parseInt(stat[2] as string, 10);
+    }
+    commits.push(commit);
+  }
+  return commits;
+}
+
+/** Parse `git diff --numstat -z` output. Plain entry: `adds\tdels\tpath NUL`;
+ *  rename entry: `adds\tdels\t NUL oldpath NUL newpath NUL` (keyed by the new path).
+ *  Binary files report `-\t-` — counted as 0/0. */
+export function parseNumstatZ(stdout: string): Array<{
+  path: string;
+  additions: number;
+  deletions: number;
+}> {
+  const tokens = stdout.split('\0');
+  const entries: Array<{ path: string; additions: number; deletions: number }> = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) continue;
+    const stat = /^(\d+|-)\t(\d+|-)\t(.*)$/s.exec(token);
+    if (!stat) continue;
+    const additions = stat[1] === '-' ? 0 : Number.parseInt(stat[1] as string, 10);
+    const deletions = stat[2] === '-' ? 0 : Number.parseInt(stat[2] as string, 10);
+    let filePath = stat[3] as string;
+    if (filePath === '') {
+      // Rename: the next two NUL-separated tokens are the old and new path.
+      i += 2;
+      filePath = tokens[i] ?? '';
+    }
+    if (filePath) entries.push({ path: filePath, additions, deletions });
+  }
+  return entries;
+}
+
+/** Parse `git diff --name-status -z` output: `STATUS NUL path NUL`, with renames/
+ *  copies as `R<score> NUL oldpath NUL newpath NUL`. Typechange and anything exotic
+ *  fold into `modified`. */
+export function parseNameStatusZ(stdout: string): Array<{
+  path: string;
+  status: ReviewFileStatus;
+  renamedFrom?: string;
+}> {
+  const tokens = stdout.split('\0');
+  const entries: Array<{ path: string; status: ReviewFileStatus; renamedFrom?: string }> = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const code = tokens[i];
+    if (!code) continue;
+    const kind = code[0];
+    if (kind === 'R' || kind === 'C') {
+      const from = tokens[++i] ?? '';
+      const to = tokens[++i] ?? '';
+      if (!to) continue;
+      if (kind === 'R') entries.push({ path: to, status: 'renamed', renamedFrom: from });
+      else entries.push({ path: to, status: 'added' }); // a copy is a new file
+      continue;
+    }
+    const filePath = tokens[++i] ?? '';
+    if (!filePath) continue;
+    const status: ReviewFileStatus = kind === 'A' ? 'added' : kind === 'D' ? 'deleted' : 'modified';
+    entries.push({ path: filePath, status });
+  }
+  return entries;
+}
+
+/** Parse `git status --porcelain -z` output into the set of paths with uncommitted
+ *  changes plus the untracked subset. Entry: `XY<space>path NUL`; a staged rename adds
+ *  a trailing `origpath NUL` token (skipped — the new path is the identity). */
+export function parsePorcelainZ(stdout: string): {
+  uncommitted: Set<string>;
+  untracked: string[];
+} {
+  const tokens = stdout.split('\0');
+  const uncommitted = new Set<string>();
+  const untracked: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const entry = tokens[i];
+    if (!entry || entry.length < 4 || entry[2] !== ' ') continue;
+    const code = entry.slice(0, 2);
+    const filePath = entry.slice(3);
+    uncommitted.add(filePath);
+    if (code === '??') untracked.push(filePath);
+    if (code[0] === 'R' || code[0] === 'C') i += 1; // skip the orig-path token
+  }
+  return { uncommitted, untracked };
+}
+
+// ── Probes ────────────────────────────────────────────────────────────────────
+
+/** Commits on the workstream branch that base doesn't have (`base..HEAD`), newest
+ *  first, each with its own diff stats. Never throws — failures land in `error`. */
+export async function reviewCommits(dir: string, base?: string): Promise<ReviewCommitsResult> {
+  const resolvedBase = base ?? (await resolveDefaultBase(dir));
+  const result: ReviewCommitsResult = { base: resolvedBase, commits: [] };
+  const invalid = await verifyRepoAndBase(dir, resolvedBase);
+  if (invalid) {
+    result.error = invalid;
+    return result;
+  }
+  const log = await runGit(dir, [
+    'log',
+    '--numstat',
+    `--format=${LOG_FORMAT}`,
+    `${resolvedBase}..HEAD`,
+  ]);
+  if (!log.ok) {
+    result.error = log.error;
+    return result;
+  }
+  result.commits = parseCommitLog(log.stdout);
+  return result;
+}
+
+/** The merge-base of base and HEAD — the same baseline `base...HEAD` uses, computed
+ *  explicitly so the working tree can be diffed against it directly (covering
+ *  committed + uncommitted in one diff) without the base's own advances ever reading
+ *  as this workstream's changes. */
+async function mergeBase(dir: string, base: string): Promise<GitResult> {
+  const result = await runGit(dir, ['merge-base', base, 'HEAD']);
+  return result.ok ? { ok: true, stdout: result.stdout.trim() } : result;
+}
+
+/** Line count of an untracked file (its entire content is an addition). Binary or
+ *  unreadable files count 0 — the entry's presence is the signal. */
+async function countLines(dir: string, file: string): Promise<number> {
+  try {
+    const buf = await fs.readFile(path.join(dir, file));
+    if (buf.length === 0) return 0;
+    if (buf.subarray(0, 8000).includes(0)) return 0; // git's own binary heuristic
+    let lines = 0;
+    for (const byte of buf) if (byte === 10) lines += 1;
+    return buf[buf.length - 1] === 10 ? lines : lines + 1;
+  } catch {
+    return 0;
+  }
+}
+
+/** Per-file diff stats vs base — committed (branch vs merge-base) and uncommitted
+ *  (working tree, incl. untracked files) combined into one list. Never throws. */
+export async function reviewFiles(dir: string, base?: string): Promise<ReviewFilesResult> {
+  const resolvedBase = base ?? (await resolveDefaultBase(dir));
+  const result: ReviewFilesResult = { base: resolvedBase, files: [] };
+  const invalid = await verifyRepoAndBase(dir, resolvedBase);
+  if (invalid) {
+    result.error = invalid;
+    return result;
+  }
+  const mb = await mergeBase(dir, resolvedBase);
+  if (!mb.ok) {
+    result.error = mb.error;
+    return result;
+  }
+
+  // Diffing the working tree against the merge-base folds committed + uncommitted
+  // changes into one net view (a change committed then reverted uncommitted nets out).
+  const numstat = await runGit(dir, ['diff', '--numstat', '-z', '-M', mb.stdout]);
+  if (!numstat.ok) {
+    result.error = numstat.error;
+    return result;
+  }
+  const nameStatus = await runGit(dir, ['diff', '--name-status', '-z', '-M', mb.stdout]);
+  if (!nameStatus.ok) {
+    result.error = nameStatus.error;
+    return result;
+  }
+  // -uall lists untracked files individually (not collapsed to their directory).
+  const porcelain = await runGit(dir, ['status', '--porcelain', '-z', '-uall']);
+  if (!porcelain.ok) {
+    result.error = porcelain.error;
+    return result;
+  }
+
+  const stats = new Map(parseNumstatZ(numstat.stdout).map((entry) => [entry.path, entry]));
+  const { uncommitted, untracked } = parsePorcelainZ(porcelain.stdout);
+
+  for (const entry of parseNameStatusZ(nameStatus.stdout)) {
+    const stat = stats.get(entry.path);
+    result.files.push({
+      path: entry.path,
+      additions: stat?.additions ?? 0,
+      deletions: stat?.deletions ?? 0,
+      status: entry.status,
+      uncommitted: uncommitted.has(entry.path),
+      ...(entry.renamedFrom ? { renamedFrom: entry.renamedFrom } : {}),
+    });
+  }
+
+  // Untracked files never appear in `git diff` — append them as uncommitted additions.
+  const seen = new Set(result.files.map((file) => file.path));
+  for (const filePath of untracked) {
+    if (seen.has(filePath)) continue;
+    result.files.push({
+      path: filePath,
+      additions: await countLines(dir, filePath),
+      deletions: 0,
+      status: 'added',
+      uncommitted: true,
+    });
+  }
+  return result;
+}
+
+/** `git diff --no-index` exits 1 when the files differ — that IS the diff here, so
+ *  exit 1 with stdout is success. Used for untracked files, which plain diff skips. */
+async function noIndexDiff(dir: string, file: string): Promise<GitResult> {
+  try {
+    const { stdout } = await execFile(
+      'git',
+      ['-C', dir, 'diff', '--no-index', '--', '/dev/null', file],
+      { maxBuffer: MAX_BUFFER },
+    );
+    return { ok: true, stdout };
+  } catch (err) {
+    const failure = err as { code?: unknown; stdout?: unknown };
+    if (failure.code === 1 && typeof failure.stdout === 'string') {
+      return { ok: true, stdout: failure.stdout };
+    }
+    return { ok: false, error: errText(err) };
+  }
+}
+
+/** The unified patch for ONE changed file vs base (committed + working tree),
+ *  capped at {@link DIFF_CAP} (`truncated` set when cut). Traversal-proof by
+ *  construction: `file` must exactly match a path git itself reported via
+ *  {@link reviewFiles} — anything else (including `../` escapes) is `unknownPath`,
+ *  and no git/fs call ever receives the raw caller path otherwise. Never throws. */
+export async function reviewDiff(
+  dir: string,
+  base: string | undefined,
+  file: string,
+): Promise<ReviewDiffResult> {
+  const files = await reviewFiles(dir, base);
+  const result: ReviewDiffResult = { base: files.base, path: file, patch: '', truncated: false };
+  if (files.error) {
+    result.error = files.error;
+    return result;
+  }
+  const entry = files.files.find((candidate) => candidate.path === file);
+  if (!entry) {
+    result.unknownPath = true;
+    result.error = `path was not reported by git as changed vs ${files.base}: ${file}`;
+    return result;
+  }
+
+  const mb = await mergeBase(dir, files.base);
+  if (!mb.ok) {
+    result.error = mb.error;
+    return result;
+  }
+  // For a rename, limit the diff to both sides so -M can pair them into one hunk.
+  const pathspecs = entry.renamedFrom ? [entry.renamedFrom, entry.path] : [entry.path];
+  let patch = await runGit(dir, ['diff', '-M', mb.stdout, '--', ...pathspecs]);
+  if (patch.ok && patch.stdout === '') {
+    // Nothing from plain diff but git reported the file ⇒ it is untracked.
+    patch = await noIndexDiff(dir, entry.path);
+  }
+  if (!patch.ok) {
+    result.error = patch.error;
+    return result;
+  }
+  // Cap by string length (~bytes for ASCII patches) — approximate is fine here.
+  if (patch.stdout.length > DIFF_CAP) {
+    result.patch = patch.stdout.slice(0, DIFF_CAP);
+    result.truncated = true;
+  } else {
+    result.patch = patch.stdout;
+  }
+  return result;
+}

--- a/engine/src/kild/room/room-manager.test.ts
+++ b/engine/src/kild/room/room-manager.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { SessionCallbacks } from '../sessions.ts';
+import { worktreePath } from '../worktree.ts';
 import { RoomManager } from './room-manager.ts';
 import { RoomRegistry } from './room-registry.ts';
 import { HUMAN, type ParticipantSpec } from './room-types.ts';
@@ -632,4 +633,54 @@ test('without memory.synthesis config, close spawns nothing extra', async () => 
   const before = spawned.length;
   await manager.close('room-1');
   expect(spawned.length).toBe(before);
+});
+
+// ── workstreamDir (the review endpoints' room→dir resolution) ─────────────────
+
+test('workstreamDir resolves a live room without a worktree to its cwd', async () => {
+  const { manager } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  // base falls all the way through to 'main' (tmp is no git checkout, no config).
+  expect(manager.workstreamDir('room-1')).toEqual({
+    ok: true,
+    value: { dir: tmp, base: 'main' },
+  });
+});
+
+test('workstreamDir resolves a worktree room to the worktree path, with its base', async () => {
+  const { manager } = fixture();
+  await manager.open('room-1', {
+    name: 'demo',
+    cwd: tmp,
+    participants: [{ name: 'worker' }],
+    worktree: 'slice-x',
+    base: 'develop',
+  });
+  const result = manager.workstreamDir('room-1');
+  expect(result.ok).toBe(true);
+  if (result.ok) {
+    expect(result.value.dir).toBe(worktreePath('slice-x'));
+    expect(result.value.base).toBe('develop');
+  }
+});
+
+test('workstreamDir on an unknown room is not_found', () => {
+  const { manager } = fixture();
+  expect(manager.workstreamDir('nope')).toEqual({
+    ok: false,
+    code: 'not_found',
+    message: 'no such live room: nope',
+  });
+});
+
+test('workstreamDir on a closed (archived) room is invalid_state', async () => {
+  const { manager } = fixture();
+  await openRoom(manager, [{ name: 'worker' }]);
+  await manager.postFromHuman('room-1', 'hello'); // history → the close archives it
+  await manager.close('room-1');
+  expect(manager.workstreamDir('room-1')).toEqual({
+    ok: false,
+    code: 'invalid_state',
+    message: 'room room-1 is archived; its workstream is gone',
+  });
 });

--- a/engine/src/kild/room/room-manager.ts
+++ b/engine/src/kild/room/room-manager.ts
@@ -270,6 +270,23 @@ export class RoomManager {
     );
   }
 
+  /** The effective workstream dir (the room's worktree if set, else its cwd) + base of
+   *  ONE live room — the same resolution {@link liveRoomsStatus} uses per room, exposed
+   *  so the review endpoints can drill into a single room without probing every room's
+   *  git state. Live rooms only: an archived room's participants are gone and its
+   *  worktree may be pruned, so there is no workstream to inspect (`invalid_state`);
+   *  an id that was never a room is `not_found`. */
+  workstreamDir(roomId: string): CommandResult<{ dir: string; base?: string }> {
+    const room = this.registry.get(roomId);
+    if (room) {
+      return ok({ dir: room.worktree ? worktreePath(room.worktree) : room.cwd, base: room.base });
+    }
+    if (this.registry.archived().some((archived) => archived.id === roomId)) {
+      return fail('invalid_state', `room ${roomId} is archived; its workstream is gone`);
+    }
+    return fail('not_found', `no such live room: ${roomId}`);
+  }
+
   /** Add a participant to a live room. `invitedBy` is the inviter's name (default
    *  {@link HUMAN} for the operator's manual invite). */
   async addParticipant(

--- a/engine/src/kild/worktree-status.ts
+++ b/engine/src/kild/worktree-status.ts
@@ -39,8 +39,9 @@ async function runGit(dir: string, args: string[]): Promise<GitResult> {
 }
 
 /** The base branch to compare against when the caller doesn't name one: the remote's
- *  default (`origin/HEAD`, minus the `origin/` prefix) if set, else `main`. */
-async function resolveDefaultBase(dir: string): Promise<string> {
+ *  default (`origin/HEAD`, minus the `origin/` prefix) if set, else `main`. Shared
+ *  with git-review so summary status and review drill-down agree on the baseline. */
+export async function resolveDefaultBase(dir: string): Promise<string> {
   const head = await runGit(dir, ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
   if (head.ok) {
     const branch = head.stdout.trim().replace(/^origin\//, '');

--- a/engine/src/server.git-review.test.ts
+++ b/engine/src/server.git-review.test.ts
@@ -1,0 +1,45 @@
+import { beforeAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Error-path tests for the review-intelligence routes, against the real Hono app
+ * (`server.ts`'s default export) via `fetch` — no port is bound (Bun only serves the
+ * default export for the entry module). KILD_HOME points at a temp dir BEFORE the
+ * dynamic import so the module's load-time side effects (project prune, room archive
+ * load) see an empty state, not the user's.
+ */
+let fetchApp: (req: Request) => Response | Promise<Response>;
+
+beforeAll(async () => {
+  process.env.KILD_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'kild-server-review-'));
+  const server = (await import('./server.ts')).default;
+  fetchApp = server.fetch as typeof fetchApp;
+});
+
+const get = (url: string) => fetchApp(new Request(`http://localhost${url}`));
+
+test.each(['commits', 'files'])('GET git/%s on an unknown room is a clean 404', async (leaf) => {
+  const res = await get(`/api/rooms/no-such-room/git/${leaf}`);
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({
+    error: 'no such live room: no-such-room',
+    code: 'not_found',
+  });
+});
+
+test('GET git/diff on an unknown room is a clean 404', async () => {
+  const res = await get('/api/rooms/no-such-room/git/diff?path=README.md');
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({
+    error: 'no such live room: no-such-room',
+    code: 'not_found',
+  });
+});
+
+test('GET git/diff without a path query is a 400', async () => {
+  const res = await get('/api/rooms/no-such-room/git/diff');
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({ error: 'path query parameter required' });
+});

--- a/engine/src/server.ts
+++ b/engine/src/server.ts
@@ -15,6 +15,7 @@ import { createBunWebSocket } from 'hono/bun';
 import { cors } from 'hono/cors';
 
 import { listAgents } from './kild/agents.ts';
+import { reviewCommits, reviewDiff, reviewFiles } from './kild/git-review.ts';
 import { addProject, findProject, loadProjects } from './kild/projects.ts';
 import {
   resolveCloseRoomActor,
@@ -414,6 +415,39 @@ app.post('/api/rooms/:id/close', async (c) => {
   const result = await roomManager.close(c.req.param('id'), { force: force === true });
   if (!result.ok) return c.json({ error: result.message }, roomResultStatus(result));
   return c.json({ ok: true, message: result.value.message });
+});
+
+// ── Review intelligence ───────────────────────────────────────────────────────
+// Git drill-down for a live room's workstream (worktree if set, else cwd — the same
+// resolution live-room status uses): commits vs the room's base, per-file diff stats
+// (committed + uncommitted), and one file's unified patch. Live rooms only — an
+// archived room's workstream dir is gone (409); unknown ids 404. Git failures inside
+// a resolved room are data ({error} in the body, per workstream-git-status), never a 500.
+app.get('/api/rooms/:id/git/commits', async (c) => {
+  const located = roomManager.workstreamDir(c.req.param('id'));
+  if (!located.ok) {
+    return c.json({ error: located.message, code: located.code }, roomResultStatus(located));
+  }
+  return c.json(await reviewCommits(located.value.dir, located.value.base));
+});
+app.get('/api/rooms/:id/git/files', async (c) => {
+  const located = roomManager.workstreamDir(c.req.param('id'));
+  if (!located.ok) {
+    return c.json({ error: located.message, code: located.code }, roomResultStatus(located));
+  }
+  return c.json(await reviewFiles(located.value.dir, located.value.base));
+});
+app.get('/api/rooms/:id/git/diff', async (c) => {
+  const file = c.req.query('path');
+  if (!file) return c.json({ error: 'path query parameter required' }, 400);
+  const located = roomManager.workstreamDir(c.req.param('id'));
+  if (!located.ok) {
+    return c.json({ error: located.message, code: located.code }, roomResultStatus(located));
+  }
+  const diff = await reviewDiff(located.value.dir, located.value.base, file);
+  // The traversal guard: only a path git itself reported may be diffed.
+  if (diff.unknownPath) return c.json({ error: diff.error }, 404);
+  return c.json(diff);
 });
 
 // ── Live stream (WebSocket) ─────────────────────────────────────────────────


### PR DESCRIPTION
## What

The git-facts data layer a review surface needs: a new `engine/src/kild/git-review.ts` module plus three live-room routes in `server.ts`. Where `worktree-status.ts` answers "how far along is this workstream?" (summary), this answers "what exactly changed?" — the drill-down.

All three routes resolve the room's effective dir exactly like `liveRoomsStatus` (worktree if set, else cwd) via a new `RoomManager.workstreamDir` accessor, and compare against the room's own `base`. Same safety contract as worktree-status: `execFile` (no shell — no injection), and git failures inside a resolved room are returned as `{error}` data, never thrown/500.

## Endpoints

### `GET /api/rooms/:id/git/commits`

Commits on the workstream branch vs its base (`base..HEAD`), newest first, with per-commit stats (`ts` is epoch millis):

```json
{
  "base": "main",
  "commits": [
    {
      "sha": "1690c0a147ded5940743bda9bd2968b38802006e",
      "subject": "feat(engine): wire review routes",
      "author": "Rasmus Widing",
      "ts": 1784891999000,
      "filesChanged": 1,
      "additions": 1,
      "deletions": 0
    },
    {
      "sha": "5227bd7b118cf64435587c0fdb540c7cade86053",
      "subject": "feat(engine): add git-review module",
      "author": "Rasmus Widing",
      "ts": 1784891999000,
      "filesChanged": 1,
      "additions": 2,
      "deletions": 0
    }
  ]
}
```

### `GET /api/rooms/:id/git/files`

Per-file diff stats vs base — committed and uncommitted folded into one net view against the merge-base (so the base's own advances never read as this workstream's changes). Untracked files appear as uncommitted additions with their line count; renames carry `renamedFrom`:

```json
{
  "base": "main",
  "files": [
    { "path": "README.md",    "additions": 1, "deletions": 0, "status": "modified", "uncommitted": true  },
    { "path": "git-review.ts","additions": 2, "deletions": 0, "status": "added",    "uncommitted": false },
    { "path": "server.ts",    "additions": 1, "deletions": 0, "status": "modified", "uncommitted": false },
    { "path": "notes.md",     "additions": 1, "deletions": 0, "status": "added",    "uncommitted": true  }
  ]
}
```

### `GET /api/rooms/:id/git/diff?path=<file>`

The unified patch for one file vs base (committed + working tree), capped at ~200 KB with `truncated: true` when cut:

```json
{
  "base": "main",
  "path": "server.ts",
  "patch": "diff --git a/server.ts b/server.ts\nindex 2d33a43..3684bdc 100644\n--- a/server.ts\n+++ b/server.ts\n@@ -1 +1,2 @@\n export const routes = 1;\n+export const reviewRoutes = 3;\n",
  "truncated": false
}
```

(Example payloads are the module's real output against a fixture repo.)

## Errors

- Unknown room → `404 {"error":"no such live room: <id>","code":"not_found"}`
- Archived room (workstream dir is gone) → `409 {"error":"room <id> is archived; its workstream is gone","code":"invalid_state"}` — typed via the existing `CommandResult`/`roomResultStatus` mapping
- `diff` without `path` → `400`; a `path` git did not itself report (incl. `../` traversal) → `404` — the raw caller path never reaches git/fs unless it exactly matches a git-reported changed file
- Git failures on a resolved room (missing base ref, broken repo, …) → `200` with `{error}` in the body, per the workstream-git-status pattern

## Notes

- `worktree-status.ts`: only change is exporting `resolveDefaultBase` so summary and drill-down agree on the default baseline.
- `server.ts` diff is append-only: one import line + one contiguous route block after the Rooms section, to keep parallel-workstream rebases trivial.
- Untracked files are diffed via `git diff --no-index /dev/null <file>` (exit 1 = success there); binary files count 0/0 in stats.

## Validation

- `bun test` — 192 pass (16 new git-review fixture/parser tests against real `mkdtemp` repos, 4 new `workstreamDir` tests, 4 endpoint error-path tests against the real Hono app)
- `bun run typecheck` — clean
- `bun run lint` — clean
