### PR TITLE
feat(room): persist cwd and base in archive snapshots

### DIFF
--- a/engine/src/kild/room/room-manager.test.ts
+++ b/engine/src/kild/room/room-manager.test.ts
@@ -743,3 +743,12 @@ test('workstreamDir on a closed (archived) room is invalid_state', async () => {
     message: 'room room-1 is archived; its workstream is gone',
   });
 });
+
+test('archived snapshots keep cwd and base so history stays project-attributable', async () => {
+  const { manager } = fixture();
+  const project = fs.mkdtempSync(path.join(tmp, 'attrproj-'));
+  await manager.open('room-1', { name: 'demo', cwd: project, participants: [{ name: 'worker' }] });
+  await manager.postFromHuman('room-1', 'work');
+  await manager.close('room-1');
+  expect(manager.archived()[0]).toMatchObject({ cwd: project });
+});

--- a/engine/src/kild/room/room-registry.ts
+++ b/engine/src/kild/room/room-registry.ts
@@ -107,6 +107,8 @@ export class RoomRegistry {
       state: r.state,
       log: r.log,
       decisions: r.decisions,
+      cwd: r.cwd,
+      base: r.base,
     }));
   }
 
@@ -130,6 +132,8 @@ export class RoomRegistry {
       state,
       log: room.log,
       decisions: room.decisions,
+      cwd: room.cwd,
+      base: room.base,
     };
   }
 

--- a/engine/src/kild/room/room-types.ts
+++ b/engine/src/kild/room/room-types.ts
@@ -201,6 +201,11 @@ export interface ArchivedRoom {
   log: RoomMessage[];
   /** Keyed decision ledger (see room-decisions). Optional: older history files predate it. */
   decisions?: RoomDecision[];
+  /** Project directory the room ran in — persisted so archived rooms stay attributable
+   *  to their project after the worktree is pruned. Optional: older files predate it. */
+  cwd?: string;
+  /** Base branch the workstream measured against. Optional: older files predate it. */
+  base?: string;
 }
 
 /** A live room enriched with its workstream's git/worktree state — the code-state


### PR DESCRIPTION
Archived rooms lose project attribution once their worktree is pruned (found during helm's projects/history slice — unattributable archives could only appear under "All projects"). One-field fix: the archive snapshot now carries the room's cwd and base as optional fields; older history files load unchanged. Test asserts the attribution survives close. 209 tests green, typecheck + lint clean.