### PR TITLE
refactor(engine): rename the fleet capability to operator

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -116,7 +116,7 @@ actors) and **slice 6** (one transport-neutral command API). Everything else bel
 history or context, not a pending work queue.
 
 **The fleet layer — SHIPPED and live-proven (2026-07-16).** The brain is a kild session
-(`kild fleet "<goal>"`, agent `brain`, `KILD_FLEET=1`) whose tools — `open_room`,
+(`kild fleet "<goal>"`, agent `brain`, `KILD_OPERATOR=1`) whose tools — `open_room`,
 `post_room`, `rooms_status`, `close_room` — are HTTP clients of the same engine REST
 surface any UI client drives (new: `POST /api/rooms[,/:id/post,/:id/close]`, participant-
 aware kickoff addressing, non-room WS `spawn/prompt/stop` restored). Memory is a durable

--- a/engine/src/cli.ts
+++ b/engine/src/cli.ts
@@ -260,7 +260,7 @@ async function fleetInteractive(goal: string): Promise<void> {
       model: values.model,
       cwd,
       projectName: values.project ?? 'fleet',
-      fleet: true,
+      operator: true,
       prompt: goal,
     });
     return void console.log(json ? JSON.stringify(res, null, 2) : res.id);
@@ -319,14 +319,14 @@ async function fleetInteractive(goal: string): Promise<void> {
           type: 'spawn',
           id,
           // The fleet driver's persona comes from the project (`--agent <name>`); with none,
-          // it's the `default` general-purpose session (kild's system prompt) plus the fleet
-          // room-control tools. kild ships no `brain` role of its own.
+          // it's the `default` general-purpose session (kild's system prompt) plus the
+          // operator room-control tools. kild ships no `brain` role of its own.
           agent: values.agent ?? 'default',
           cwd,
           model: values.model,
           worktree: values.worktree,
           projectName: values.project ?? 'fleet',
-          env: { KILD_FLEET: '1' },
+          env: { KILD_OPERATOR: '1' },
         }),
       );
       ws.send(JSON.stringify({ type: 'prompt', id, text: goal }));

--- a/engine/src/kild/fleet/close-room-tool.ts
+++ b/engine/src/kild/fleet/close-room-tool.ts
@@ -3,7 +3,7 @@ import { Type } from 'typebox';
 
 import { closeRoom } from './engine-client.ts';
 
-export function createFleetCloseRoomTool(): ToolDefinition {
+export function createOperatorCloseRoomTool(): ToolDefinition {
   return {
     name: 'close_room',
     label: 'Close Room',

--- a/engine/src/kild/fleet/engine-client.ts
+++ b/engine/src/kild/fleet/engine-client.ts
@@ -78,8 +78,8 @@ export interface SpawnSessionRequest {
   worktree?: string;
   base?: string;
   projectName?: string;
-  /** Grant the fleet room-control tools (open/post/status/close rooms). */
-  fleet?: boolean;
+  /** Grant the operator room-control tools (open/post/status/close rooms). */
+  operator?: boolean;
   /** Absolute pi session file to fork from — the spawned session starts from a frozen
    *  copy of its history (a new session file; the source is never written). */
   forkFrom?: string;

--- a/engine/src/kild/room/room-manager.ts
+++ b/engine/src/kild/room/room-manager.ts
@@ -193,7 +193,7 @@ export class RoomManager {
       cwd: spec.cwd,
       worktree: spec.worktree,
       // Resolve the base once here — the single chokepoint every opener (CLI, REST, WS,
-      // fleet tool) flows through: explicit `base` wins, else the cwd's configured
+      // operator tool) flows through: explicit `base` wins, else the cwd's configured
       // `baseBranch`, else its current branch, else `main`.
       base: await resolveBaseBranch(spec.cwd, spec.base),
       openedBy: spec.openedBy,

--- a/engine/src/kild/sessions.ts
+++ b/engine/src/kild/sessions.ts
@@ -79,7 +79,7 @@ export function workerEnv(
     KILD_MODEL: req.model ?? '',
     KILD_CWD: req.cwd ?? process.cwd(),
     KILD_AGENT: req.agent ?? '',
-    // Session identity is manager-owned: fleet tools use it to identify room openers.
+    // Session identity is manager-owned: operator tools use it to identify room openers.
     KILD_SESSION_ID: id,
     // The worktree *name*; the worker ensures it from KILD_CWD (the repo).
     KILD_WORKTREE: req.worktree ?? '',

--- a/engine/src/server.ts
+++ b/engine/src/server.ts
@@ -284,7 +284,7 @@ app.get('/api/sessions/:id/transcript', async (c) => {
 app.get('/api/sessions', (c) => c.json(sessionManager.list()));
 
 // Spawn a detached session (e.g. a `kild fleet` driver) — the CLI/scripts drive this over
-// REST instead of holding a WS open. `fleet: true` grants the room-control tools.
+// REST instead of holding a WS open. `operator: true` grants the room-control tools.
 // `forkFrom` spawns the session from a frozen copy of an existing pi session file: the
 // fork gets a NEW session file and never writes the source.
 app.post('/api/sessions', async (c) => {
@@ -295,7 +295,7 @@ app.post('/api/sessions', async (c) => {
     worktree?: string;
     base?: string;
     projectName?: string;
-    fleet?: boolean;
+    operator?: boolean;
     prompt?: string;
     forkFrom?: unknown;
   };
@@ -319,7 +319,7 @@ app.post('/api/sessions', async (c) => {
       base: body.base,
       projectName: body.projectName,
       forkFrom: body.forkFrom,
-      env: body.fleet ? { KILD_FLEET: '1' } : undefined,
+      env: body.operator ? { KILD_OPERATOR: '1' } : undefined,
     },
     'cli',
   );

--- a/engine/src/worker.ts
+++ b/engine/src/worker.ts
@@ -12,7 +12,7 @@ import {
 import { resolveAgentInstructions } from './kild/agents.ts';
 import { configuredMemoryDir, configuredModels, resolvePluginPaths } from './kild/config.ts';
 import { type RawAgentEvent, translate, type UiEvent } from './kild/events.ts';
-import { createFleetCloseRoomTool } from './kild/fleet/close-room-tool.ts';
+import { createOperatorCloseRoomTool } from './kild/fleet/close-room-tool.ts';
 import { createOpenRoomTool } from './kild/fleet/open-room-tool.ts';
 import { createPostRoomTool } from './kild/fleet/post-room-tool.ts';
 import { createRoomsStatusTool } from './kild/fleet/rooms-status-tool.ts';
@@ -49,7 +49,7 @@ export async function runWorker(): Promise<never> {
   const modelPattern = process.env.KILD_MODEL || undefined;
   const inRoom = !!process.env.KILD_ROOM;
   const isRoomLead = process.env.KILD_ROOM_LEAD === '1';
-  const fleetEnabled = process.env.KILD_FLEET === '1';
+  const operatorEnabled = process.env.KILD_OPERATOR === '1';
   const skillsProfile = process.env.KILD_SKILLS_PROFILE || undefined;
   const forkFrom = process.env.KILD_FORK_SESSION || undefined;
 
@@ -97,7 +97,7 @@ export async function runWorker(): Promise<never> {
   try {
     model = resolveModel(registry, modelPattern);
     // A room participant gets `post_message` + `invite_agent`; the room's LEAD also
-    // gets `close_room` (ending the room is the lead's explicit act). A fleet-enabled
+    // gets `close_room` (ending the room is the lead's explicit act). An operator-enabled
     // non-room session instead gets the engine REST room-control tools.
     const customTools = inRoom
       ? [
@@ -110,12 +110,12 @@ export async function runWorker(): Promise<never> {
             ? [createCloseRoomTool((spec) => emitRoomCommand({ kind: 'close_room', ...spec }))]
             : []),
         ]
-      : fleetEnabled
+      : operatorEnabled
         ? [
             createOpenRoomTool(),
             createPostRoomTool(),
             createRoomsStatusTool(),
-            createFleetCloseRoomTool(),
+            createOperatorCloseRoomTool(),
           ]
         : undefined;
     // Skills: an explicit room capability profile (KILD_SKILLS_PROFILE) is EXCLUSIVE — it
@@ -199,16 +199,16 @@ export async function runWorker(): Promise<never> {
   // Every session gets the generic mechanism guide (how to operate) on top of everything,
   // above the persona — so even a bare `default` session is competent. One-shot: it rides
   // only the first delivered turn. The room-comms part is conditional inside the prompt.
-  // A delegating session (room or fleet) also gets the configured model catalog so it can
-  // pick a model per fan-out agent.
+  // A delegating session (room or operator) also gets the configured model catalog so it
+  // can pick a model per fan-out agent.
   const modelsSection =
-    inRoom || fleetEnabled ? formatModelsSection(await configuredModels(cwd)) : '';
-  // Persistent memory rides the first turn: fleet drivers get the operator's cross-project
-  // memory; every session gets the project's curated memory + direction, read from the
-  // resolved memory dir (config `memory.dir`, default `.kild/` — gitignored, so worktree
-  // checkouts never carry the default-dir files).
+    inRoom || operatorEnabled ? formatModelsSection(await configuredModels(cwd)) : '';
+  // Persistent memory rides the first turn: operator sessions get the operator's
+  // cross-project memory; every session gets the project's curated memory + direction,
+  // read from the resolved memory dir (config `memory.dir`, default `.kild/` — gitignored,
+  // so worktree checkouts never carry the default-dir files).
   const memorySections = [
-    fleetEnabled ? fleetMemorySection() : '',
+    operatorEnabled ? fleetMemorySection() : '',
     projectMemorySection(cwd, await configuredMemoryDir(cwd)),
   ]
     .filter(Boolean)

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -628,6 +628,9 @@ export default function (pi: PiExtensionAPI) {
     },
   });
 
+  // The kild_fleet_* tool NAMES are model-facing API — renaming them changes prompts and
+  // agent behavior, so they keep the historical "fleet" name even though the engine
+  // capability they request is now `operator` (POST /api/sessions {operator:true}).
   pi.registerTool({
     name: 'kild_fleet_start',
     label: 'kild: start fleet driver',
@@ -652,7 +655,7 @@ export default function (pi: PiExtensionAPI) {
           agent: p.agent ?? 'default',
           model: p.model,
           projectName: 'fleet',
-          fleet: true,
+          operator: true,
           prompt: p.goal,
         }),
       });


### PR DESCRIPTION
## What

The session capability that grants the room-control tools (`open_room`, `post_room`, `rooms_status`, `close_room`) was named **fleet** — a word already doing three jobs (the capability flag, a project's rooms, all rooms). The flag is a tool grant, and kild's existing vocabulary for the role holding those tools is **operator** (operator notifications, `resolveOpenRoomActor`, CLAUDE.md's "the operator is an agent by default"). This renames the capability to match.

## Changes

- **REST**: `POST /api/sessions` takes `{operator: true}` instead of `{fleet: true}`. Clean break, no alias — no external callers exist, and kild's own rule is "No Shims, No Backwards Compat".
- **engine-client**: `SpawnSessionRequest.fleet` → `operator`.
- **worker env**: `KILD_FLEET` → `KILD_OPERATOR`; `fleetEnabled` → `operatorEnabled`.
- **worker tools**: `createFleetCloseRoomTool` → `createOperatorCloseRoomTool` (internal name only — the registered model-facing tool name `close_room` is unchanged).
- **Callers updated**: `kild fleet --detach` (REST spawn), `kild fleet` interactive (WS spawn env), pi-extension `kild_fleet_start` body.
- Comments/prose that meant the *capability* ("fleet-enabled", "fleet tools", "fleet room-control tools") now say operator; `HANDOVER.md`'s `KILD_FLEET=1` reference updated.

## Deliberately out of scope — follow-ups for the naming audit

- The `kild fleet` **CLI verb** (user-facing command name).
- The `engine/src/kild/fleet/` **directory name**.
- The pi-extension's `kild_fleet_*` **tool names** — model-facing API; renaming changes prompts/behavior. Flagged with a code comment pointing at the new capability name.
- `fleetMemorySection` / `<fleet-memory>` — "fleet" there is the *scope* sense (cross-project memory), not the capability.
- helm (Sources/Helm) checked: **no use of the flag** — nothing to change there.

## Validation

- `bun run typecheck` clean, `bun run lint` clean, `bun test` 209 pass / 0 fail.
- `grep -rn KILD_FLEET` and `grep -rn 'fleet:' --include='*.ts'` across the repo: zero hits.