### PR TITLE
chore(engine): pin pi SDK 0.82.1

### DIFF
--- a/engine/bun.lock
+++ b/engine/bun.lock
@@ -6,8 +6,8 @@
       "name": "kild-engine",
       "dependencies": {
         "@earendil-works/pi-agent-core": "*",
-        "@earendil-works/pi-ai": "^0.80.7",
-        "@earendil-works/pi-coding-agent": "0.80.7",
+        "@earendil-works/pi-ai": "0.82.1",
+        "@earendil-works/pi-coding-agent": "0.82.1",
         "@flue/runtime": "^0.9.2",
         "hono": "^4.8.3",
         "just-bash": "^3.0.1",
@@ -116,11 +116,11 @@
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.78.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.78.1", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-oPwVRkkAvyKPWyM7E4k+EaTNmynbYn7ZLG/LBh9BUnMNb2gvpMp+VQ420R6JCJ20uogSqrHnWTyosSa/rU8lVw=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.7", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.7", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.7", "@earendil-works/pi-ai": "^0.80.7", "@earendil-works/pi-tui": "^0.80.7", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.82.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.82.1", "@earendil-works/pi-ai": "^0.82.1", "@earendil-works/pi-tui": "^0.82.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.7", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.82.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -900,7 +900,7 @@
 
     "@earendil-works/pi-agent-core/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.78.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-CM2pkTs1iupG/maw381lC9Q/Y/aQaMGK7GILc28ttImD0ci3LDwKroDsGkWbly5JIy3iqxdRxB9JlG7vvzCzTg=="],
 
-    "@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.7", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.7", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-EFjyAuoz2kn24sR9Q5A86sZCG6mD+nz58DCsA2I2wxgmS50cF1tSLCBOZaHKI5U9Y3pJs4BefeK3LRkB5TdJag=="],
+    "@earendil-works/pi-coding-agent/@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.82.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg=="],
 
     "@flue/runtime/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.78.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-CM2pkTs1iupG/maw381lC9Q/Y/aQaMGK7GILc28ttImD0ci3LDwKroDsGkWbly5JIy3iqxdRxB9JlG7vvzCzTg=="],
 

--- a/engine/package.json
+++ b/engine/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "*",
-    "@earendil-works/pi-ai": "^0.80.7",
-    "@earendil-works/pi-coding-agent": "0.80.7",
+    "@earendil-works/pi-ai": "0.82.1",
+    "@earendil-works/pi-coding-agent": "0.82.1",
     "@flue/runtime": "^0.9.2",
     "hono": "^4.8.3",
     "just-bash": "^3.0.1",

--- a/engine/src/kild/auth.ts
+++ b/engine/src/kild/auth.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-// pi-ai owns the OAuth mechanism; this is the bridge the coding-agent uses too.
-import { getOAuthApiKey } from '@earendil-works/pi-ai/oauth';
+// ModelRuntime owns credential storage + OAuth refresh (pi-ai's mechanism underneath);
+// resolving through it is exactly what the coding agent itself does.
+import { ModelRuntime } from '@earendil-works/pi-coding-agent';
 import { configureProvider } from '@flue/runtime';
 
 type AuthEntry = { type?: string; key?: string; access?: string; expires?: number };
@@ -11,7 +12,7 @@ type AuthFile = Record<string, AuthEntry>;
  * Bridge pi's stored credentials (`~/.pi/agent/auth.json`) into Flue's provider
  * config. This closes the one real auth gap from the first spike pass: Flue's
  * runtime does not read auth.json, so the user's Claude Max / ChatGPT OAuth
- * subscriptions didn't work. pi-ai's `getOAuthApiKey` refreshes the token and
+ * subscriptions didn't work. `ModelRuntime.getAuth` refreshes the token and
  * returns it; the anthropic/openai-codex providers detect an OAuth token (an
  * `sk-ant-oat…` shaped key) and switch to Bearer + the right beta headers
  * automatically — so passing it as `apiKey` is all that's needed.
@@ -30,11 +31,14 @@ export async function bridgePiAuth(): Promise<string[]> {
   const bridged: string[] = [];
 
   // OAuth subscriptions (Claude Pro/Max, ChatGPT Codex): refresh + pass token.
+  // The runtime reads the same auth.json; created lazily only when OAuth entries exist.
+  let runtime: ModelRuntime | undefined;
   for (const id of ['anthropic', 'openai-codex'] as const) {
     if (auth[id]?.type !== 'oauth') continue;
-    const result = await getOAuthApiKey(id, auth as never);
-    if (result) {
-      configureProvider(id, { apiKey: result.apiKey });
+    runtime ??= await ModelRuntime.create();
+    const apiKey = (await runtime.getAuth(id))?.auth.apiKey;
+    if (apiKey) {
+      configureProvider(id, { apiKey });
       bridged.push(id);
     }
   }

--- a/engine/src/worker.ts
+++ b/engine/src/worker.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from 'node:crypto';
 
 import {
-  AuthStorage,
   createAgentSession,
   DefaultResourceLoader,
   getAgentDir,
   ModelRegistry,
+  ModelRuntime,
   SessionManager as PiSessionManager,
 } from '@earendil-works/pi-coding-agent';
 
@@ -81,9 +81,6 @@ export async function runWorker(): Promise<never> {
     }
   }
 
-  const authStorage = AuthStorage.create();
-  const registry = ModelRegistry.create(authStorage);
-
   // Per-turn state for the implicit-reply rule (room only): the turn's sender, whether
   // the agent posted explicitly this turn, and its accumulated final text. Reset at
   // the start of each turn (in drainPrompts).
@@ -95,6 +92,10 @@ export async function runWorker(): Promise<never> {
   let model: ReturnType<typeof resolveModel>;
   let session: Awaited<ReturnType<typeof createAgentSession>>['session'];
   try {
+    // The canonical model/auth runtime (reads ~/.pi/agent auth.json + models.json);
+    // ModelRegistry is the synchronous facade over it that resolveModel reads.
+    const modelRuntime = await ModelRuntime.create();
+    const registry = new ModelRegistry(modelRuntime);
     model = resolveModel(registry, modelPattern);
     // A room participant gets `post_message` + `invite_agent`; the room's LEAD also
     // gets `close_room` (ending the room is the lead's explicit act). An operator-enabled
@@ -149,8 +150,7 @@ export async function runWorker(): Promise<never> {
     const piSessionManager = forkFrom ? PiSessionManager.forkFrom(forkFrom, cwd) : undefined;
     ({ session } = await createAgentSession({
       model,
-      authStorage,
-      modelRegistry: registry,
+      modelRuntime,
       cwd,
       customTools,
       resourceLoader,


### PR DESCRIPTION
Bumps `@earendil-works/pi-coding-agent` and `@earendil-works/pi-ai` 0.80.7 → 0.82.1, both pinned exact (`bun update` has left pi behind before, so no `^`).

## What moved between 0.80.7 → 0.82.1 and affected kild

- **Auth/model plumbing was rebuilt around `ModelRuntime`.** `AuthStorage` is no longer exported and `ModelRegistry.create(authStorage)` is gone. The canonical object is now `await ModelRuntime.create()` (async; reads `~/.pi/agent/auth.json` + `models.json`, owns OAuth refresh); `ModelRegistry` survives as a synchronous facade constructed with `new ModelRegistry(runtime)`. `worker.ts` now creates the runtime inside the session try block (a failure surfaces as a `UiEvent` error instead of a bare crash).
- **`createAgentSession` options:** `authStorage` + `modelRegistry` were replaced by a single `modelRuntime` option. `cwd`, `model`, `customTools`, `resourceLoader`, `sessionManager` are unchanged.
- **pi-ai `/oauth` entry point is type-only now** — `getOAuthApiKey` is gone. The Flue auth bridge (`kild/auth.ts`) resolves tokens via `ModelRuntime.getAuth(providerId)` instead, which runs the same refresh path the coding agent itself uses (plus credential-store locking, so concurrent refreshes can't rotate a token out from under each other).

## What did NOT move (verified against the new dist)

- `SessionManager.forkFrom(sourcePath, targetCwd, sessionDir?, options?)` — identical signature; the fork contract test (new file, `parentSession` header, source never written) passes unchanged.
- `getSessionId()` / `getSessionFile()` — unchanged (`getSessionFile` was already `string | undefined` in 0.80.7).
- **Session-file format** — still `CURRENT_SESSION_VERSION = 3`; the only schema change is optional `usage` fields on compaction/branch-summary entries, which the defensive transcript parser ignores. Old/archived session files parse as before; no parser or fixture changes needed.
- `DefaultResourceLoader` options (`cwd`/`agentDir`/`noSkills`/`additionalSkillPaths`) — unchanged.
- **Extension API surface the pi extension duck-types** — `registerTool` (name/label/description/parameters/execute), `on('before_agent_start')` (event + result both still carry `systemPrompt`), `sendUserMessage(content, { deliverAs: 'steer' | 'followUp' })` — all unchanged; no pi-extension changes.
- The `AgentSessionEvent` shapes `events.ts` translates (`message_update`/`text_delta`, `tool_execution_start/end`, `auto_retry_start`, `agent_end`) — unchanged.

## Validation

- `bun install` clean
- `bun test`: 209 pass / 0 fail (incl. `worker.fork.test.ts` + transcript tests against the new SDK)
- `bun run typecheck` and `bun run lint` green

Note: top-level `@earendil-works/pi-agent-core` (dep `"*"`) stays at its pre-existing lockfile resolution 0.78.1; the SDK nests its own 0.82.1, so the SDK path is self-consistent. Left untouched to keep this change minimal.