### PR TITLE
fix(cli): an attached agent can name itself, and find its own kild

### DIFF
--- a/docs/attached-agents.md
+++ b/docs/attached-agents.md
@@ -121,13 +121,16 @@ never writes into `~/.claude`. Wire it by hand:
 }
 ```
 
-and in the environment of the session you want attached:
+then, from any session, at any time:
 
 ```bash
-export KILD_KILD_ID=<kild id from `kild ls`>   # unset ⇒ the hook does nothing at all
-export KILD_HANDLE=claude                      # optional, defaults to `claude`
-kild attach "$KILD_KILD_ID" --as "$KILD_HANDLE"
+kild attach <kild id from `kild ls`> --as claude    # the whole setup
 ```
+
+`attach` records that against the session that ran it and the hook resolves the same id, so no
+environment variable is involved and no relaunch is needed. `KILD_KILD_ID`/`KILD_HANDLE` still
+pin a session up front, but they now **lose** to an actual attach (see below), and there is no
+longer a default handle — an attach knows which handle it claimed, so nothing guesses one.
 
 With mail waiting, the hook prints Stop-hook JSON and exits 0
 ([hook contract](https://code.claude.com/docs/en/hooks), verified 2026-07-27):

--- a/docs/attached-agents.md
+++ b/docs/attached-agents.md
@@ -78,10 +78,24 @@ id on every start including resumes, it cannot be cleared from a shell, and a st
 pointing at an archived kild would otherwise drain nothing forever while reporting success.
 An `attach` is a deliberate act naming a kild that existed; ambient config loses to it.
 
-Records live in `$KILD_HOME/attached/<session>.json`. Attaching supersedes any other session
-holding the same `(kild, handle)`, so forks cannot accumulate one record per relaunch and two
-sessions can never race on one destructive inbox. An unreadable or malformed record reads as
-*not attached* — a turn-end hook must degrade to silence, never to an error.
+Two files back this:
+
+```
+$KILD_HOME/attached/<session>.json          what this session attached to
+$KILD_HOME/attached/claims/<kild>/<handle>  which session currently holds that handle
+```
+
+The claim is written by atomic rename, so concurrent attaches to one handle resolve to exactly
+one winner — a session resolves only if the claim still names it. Superseded records are left
+on disk rather than deleted: deletion cannot be made race-free, it is not what makes this
+correct, and nothing scans the directory (every read is a direct path lookup), so the cost is
+bytes. An unreadable or malformed record reads as *not attached* — a turn-end hook must degrade
+to silence, never to an error.
+
+> **Pick handles that differ by more than case.** On a case-insensitive filesystem (the macOS
+> default) `Alice` and `alice` are two agents to the engine but one claim file, so the second
+> attach silently takes the first one's handle and the first session reads as not attached. It
+> can never resolve to the *wrong* identity, but it does go quiet.
 
 ## Inbox semantics
 

--- a/docs/attached-agents.md
+++ b/docs/attached-agents.md
@@ -22,6 +22,7 @@ cannot do — including `stop`.
 kild attach <kild-id> --as claude     # register; idempotent, spawns nothing
 kild inbox  <kild-id> --as claude     # destructive read of the inbox
 kild inbox  <kild-id> --as claude --format claude-stop   # ...shaped as a Stop hook
+kild inbox --format claude-stop       # ...or omit both: resolve what this session attached to
 ```
 
 Over REST (`POST` for both — a drain mutates, so a GET would let a proxy or a retry silently
@@ -44,6 +45,43 @@ engine attributes your messages to **that handle**. Without it an attached sende
 session to be recognised by and reads as the unattributed label `human`, so two attached
 agents in one kild were indistinguishable on the log. Re-attaching returns the same token; it
 dies with the kild. Details: `docs/api-surface.md` §4.
+
+`kild send` does this for you: it mints the token through the idempotent `attach` at call
+time and presents it. **The token is never written to disk** — it lives in engine memory and
+dies with the engine, so a stored copy would outlive it and be rejected as unknown on the
+next send. Minting is a loopback round-trip and always fresh.
+
+An agent the engine **spawned** is deliberately excluded: it already proves itself with
+`KILD_AGENT_ID`, and since the engine sets `KILD_KILD_ID`/`KILD_HANDLE` on owned agents too,
+attaching one would claim a second, shadow handle over the agent's own.
+
+### Finding your kild without being told
+
+A process's environment is fixed at exec time, so a session cannot be handed the id of a kild
+opened *after* it started — which is the normal case, since you decide to delegate mid-session.
+A resumed or forked session is worse: its environment is rebuilt from a harness settings file
+the shell does not own, so nothing you export can reach it.
+
+`attach` therefore records `{kild, handle}` against the **harness session id** — an opaque
+string kild stores and hands back. Only the hook knows where that id comes from; the engine
+never learns about any harness. `kild inbox` and `kild send` resolve it, so attaching
+mid-session Just Works with no relaunch.
+
+Resolution order, highest first:
+
+1. an explicit argument (`<id>`, `--as`, `--session`);
+2. **this session's recorded attach**;
+3. `KILD_KILD_ID` / `KILD_HANDLE`.
+
+The record outranks the environment on purpose. A harness settings file can re-inject a kild
+id on every start including resumes, it cannot be cleared from a shell, and a stale entry
+pointing at an archived kild would otherwise drain nothing forever while reporting success.
+An `attach` is a deliberate act naming a kild that existed; ambient config loses to it.
+
+Records live in `$KILD_HOME/attached/<session>.json`. Attaching supersedes any other session
+holding the same `(kild, handle)`, so forks cannot accumulate one record per relaunch and two
+sessions can never race on one destructive inbox. An unreadable or malformed record reads as
+*not attached* — a turn-end hook must degrade to silence, never to an error.
 
 ## Inbox semantics
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -165,11 +165,34 @@ that list), and the `kild/<name>` branch always survives, so force costs no comm
 | Var | Status |
 |---|---|
 | `KILD_HOME` · `KILD_PORT` · `KILD_ENGINE` | unchanged |
-| `KILD_ROOM` → `KILD_KILD_ID` | renamed (Stop-hook wiring) |
-| `KILD_PARTICIPANT` → `KILD_HANDLE` | renamed (Stop-hook wiring) |
+| `KILD_ROOM` → `KILD_KILD_ID` | renamed (Stop-hook wiring), and **demoted** — see below |
+| `KILD_PARTICIPANT` → `KILD_HANDLE` | renamed (Stop-hook wiring), and **demoted** — see below |
 | `KILD_OPERATOR` | **removed** — the operator tier is gone |
 | `KILD_ROLE=worker` → `KILD_ROLE=agent` | renamed (internal; only matters if you invoke the worker directly) |
 | `KILD_SESSION_ID` → `KILD_AGENT_ID` | renamed (internal — the engine sets it on every agent it spawns). `session` means pi's conversation and nothing else, and this is the engine's own id for an agent's process. The REST field it is presented as renamed with it: `sessionId` → `agentId`. |
+
+## Attaching no longer needs the environment
+
+`kild attach` now records `{kild, handle}` against the harness session id, and `kild inbox` /
+`kild send` resolve it. Two consequences for an existing setup:
+
+- **`kild attach <id> --as <handle>` is the whole setup.** You no longer have to relaunch a
+  session from a prepared shell to attach it to a kild opened after it started. Re-wire the
+  Stop hook by copying `hooks/claude-stop` again — it now reads `session_id` off the hook
+  payload instead of gating on `$KILD_KILD_ID`.
+- **`KILD_KILD_ID` / `KILD_HANDLE` still work, but they now LOSE to an actual attach.** They
+  were the highest-priority source and are now the lowest. If you pinned a session by
+  exporting them, that still works; if you export them *and* attach, the attach wins.
+
+  This inversion is deliberate. A harness settings file (`.claude/settings.local.json` and
+  friends) is re-read on every session start including resumes, outranks anything a shell
+  exports, and cannot be cleared from the shell — so a stale entry naming an archived kild is
+  invisible and would drain nothing forever while reporting success. **Check yours now:** a
+  leftover `KILD_ROOM`/`KILD_PARTICIPANT` there is exactly this trap, and renaming the vars
+  did not remove it.
+
+- **The hook's `claude` handle default is gone.** It guessed a handle for a session that had
+  not said which one it held; the record now knows. Set `KILD_HANDLE` if you want to pin one.
 
 ## For helm and other API clients
 

--- a/engine/src/cli.attached.test.ts
+++ b/engine/src/cli.attached.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, expect, test } from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -22,14 +24,23 @@ interface Drained {
 
 let engine: ReturnType<typeof Bun.serve> | undefined;
 let engineUrl = '';
+/** Throwaway `$KILD_HOME` — attachment records land here, never in the operator's config. */
+let kildHome = '';
 /** What the next /drain call answers with — set per test. */
 let drainResponse: { status: number; body: unknown } = {
   status: 200,
   body: { ok: true, messages: [], idle: true, capped: false },
 };
 let drainRequests: Array<{ method: string; path: string; body: unknown }> = [];
+/** `Authorization` per request, in order. Kept beside `drainRequests` rather than inside it
+ *  so the exact-shape assertions already written here keep passing. */
+let authHeaders: Array<string | null> = [];
+/** What an `attach` answers with, when a test needs it to differ from `drainResponse` — a
+ *  send mints its credential through attach, so those tests need both to be distinct. */
+let attachResponse: { status: number; body: unknown } | undefined;
 
-beforeAll(() => {
+beforeAll(async () => {
+  kildHome = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'kild-cli-')));
   engine = Bun.serve({
     port: 0, // ephemeral — never the operator's 4517
     hostname: '127.0.0.1',
@@ -40,17 +51,52 @@ beforeAll(() => {
         path: url.pathname,
         body: await request.json().catch(() => undefined),
       });
+      authHeaders.push(request.headers.get('authorization'));
+      if (url.pathname.endsWith('/agents/attach') && attachResponse) {
+        return Response.json(attachResponse.body, { status: attachResponse.status });
+      }
       return Response.json(drainResponse.body, { status: drainResponse.status });
     },
   });
   engineUrl = `http://127.0.0.1:${engine.port}`;
 });
 
-afterAll(() => engine?.stop(true));
+afterAll(async () => {
+  engine?.stop(true);
+  await fs.rm(kildHome, { recursive: true, force: true });
+});
 
-async function runCli(args: string[], engineOverride?: string) {
+/**
+ * The variables the CLI resolves an identity from, scrubbed on every run unless a test asks
+ * for one by name.
+ *
+ * Inheriting the ambient environment made this suite depend on whose machine it ran on: an
+ * operator whose own session is attached exports `KILD_KILD_ID`, `KILD_HANDLE` and
+ * `CLAUDE_CODE_SESSION_ID`, and the CLI under test would resolve THEIR attachment and issue
+ * calls no test expected. `KILD_HOME` is redirected rather than dropped so a run can never
+ * write an attachment record into the operator's real config directory.
+ */
+const IDENTITY_ENV = [
+  'KILD_KILD_ID',
+  'KILD_HANDLE',
+  'KILD_AGENT_ID',
+  'CLAUDE_CODE_SESSION_ID',
+] as const;
+
+async function runCli(
+  args: string[],
+  engineOverride?: string,
+  identity: Partial<Record<(typeof IDENTITY_ENV)[number], string>> = {},
+) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    KILD_ENGINE: engineOverride ?? engineUrl,
+    KILD_HOME: kildHome,
+  };
+  for (const key of IDENTITY_ENV) delete env[key];
+  Object.assign(env, identity);
   const proc = Bun.spawn(['bun', 'run', CLI, ...args], {
-    env: { ...process.env, KILD_ENGINE: engineOverride ?? engineUrl },
+    env: env as Record<string, string>,
     stdout: 'pipe',
     stderr: 'pipe',
   });
@@ -221,5 +267,114 @@ test('attach sends the handle to the engine and reports what happened', async ()
   expect(drainRequests).toEqual([
     { method: 'POST', path: '/api/kilds/kild-1/agents/attach', body: { handle: 'claude' } },
   ]);
+  withNoMail();
+});
+
+/**
+ * Attach discovery: what a session can work out about itself without being told.
+ *
+ * A process's environment is fixed at exec time, so a session cannot be handed the id of a
+ * kild opened after it started — and a resumed or forked session cannot be handed anything
+ * at all, because its environment is rebuilt from a settings file the shell does not own.
+ * The session id is the only thing that survives, so it is what the attachment is keyed to.
+ */
+test('attach records the session, and inbox with no arguments resolves it', async () => {
+  drainResponse = { status: 200, body: { ok: true, message: "@kild attached to kild 'demo'." } };
+  const attached = await runCli(['attach', 'kild-9', '--as', 'kild'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-discovery',
+  });
+  expect(attached.exitCode).toBe(0);
+
+  withNoMail();
+  drainRequests = [];
+  // No id, no --as, and nothing in the environment — exactly a hook on a session that
+  // attached mid-flight.
+  const drained = await runCli(['inbox', '--format', 'claude-stop'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-discovery',
+  });
+  expect(drained.exitCode).toBe(0);
+  expect(drainRequests).toEqual([
+    { method: 'POST', path: '/api/kilds/kild-9/inbox/drain', body: { handle: 'kild' } },
+  ]);
+});
+
+test('an actual attach outranks a stale kild id in the environment', async () => {
+  drainResponse = { status: 200, body: { ok: true, message: 'attached' } };
+  await runCli(['attach', 'kild-live', '--as', 'kild'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-stale',
+  });
+
+  withNoMail();
+  drainRequests = [];
+  // A harness settings file can re-inject a kild id on every start, including resumes, and
+  // no shell can clear it. Ranking it below a real attach is what stops a session draining
+  // an archived kild forever while reporting nothing wrong.
+  const drained = await runCli(['inbox', '--format', 'claude-stop'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-stale',
+    KILD_KILD_ID: 'kild-archived',
+  });
+  expect(drained.exitCode).toBe(0);
+  expect(drainRequests[0]?.path).toBe('/api/kilds/kild-live/inbox/drain');
+});
+
+test('an attached send presents the attach token, so the log names the sender', async () => {
+  attachResponse = { status: 200, body: { ok: true, message: 'attached', token: 'tok-xyz' } };
+  await runCli(['attach', 'kild-9', '--as', 'kild'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-send',
+  });
+
+  drainResponse = { status: 200, body: { ok: true, message: 'Sent to the kild.' } };
+  drainRequests = [];
+  authHeaders = [];
+  const sent = await runCli(['send', 'kild-9', '--to', 'claude', 'hello'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-send',
+  });
+  expect(sent.exitCode).toBe(0);
+
+  // The credential is minted through the idempotent attach at call time rather than stored:
+  // tokens live in engine memory and a copy on disk would outlive them.
+  const message = drainRequests.findIndex((r) => r.path === '/api/kilds/kild-9/messages');
+  expect(message).toBeGreaterThanOrEqual(0);
+  expect(authHeaders[message]).toBe('Bearer tok-xyz');
+  attachResponse = undefined;
+  withNoMail();
+});
+
+test('an agent the engine spawned sends as itself and never attaches a shadow handle', async () => {
+  drainResponse = { status: 200, body: { ok: true, message: 'Sent to the kild.' } };
+  drainRequests = [];
+  authHeaders = [];
+  // The engine sets KILD_KILD_ID and KILD_HANDLE on the agents it spawns as well, so without
+  // the agent-id guard this send would attach a second, shadow copy of the agent over its own
+  // handle and then speak through it.
+  const sent = await runCli(['send', 'kild-9', '--to', 'claude', 'hi'], undefined, {
+    KILD_AGENT_ID: 'agent-7',
+    KILD_KILD_ID: 'kild-9',
+    KILD_HANDLE: 'coder',
+  });
+  expect(sent.exitCode).toBe(0);
+  expect(drainRequests.map((r) => r.path)).toEqual(['/api/kilds/kild-9/messages']);
+  expect(drainRequests[0]?.body).toMatchObject({ agentId: 'agent-7' });
+  expect(authHeaders[0]).toBeNull();
+  withNoMail();
+});
+
+test('a send to a kild this session is not attached to presents no credential', async () => {
+  drainResponse = { status: 200, body: { ok: true, message: 'attached' } };
+  await runCli(['attach', 'kild-mine', '--as', 'kild'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-scope',
+  });
+
+  drainResponse = { status: 200, body: { ok: true, message: 'Sent to the kild.' } };
+  drainRequests = [];
+  authHeaders = [];
+  // A handle is unique within one kild and means nothing outside it, so there is no identity
+  // to present — and attaching one here would silently claim a handle in someone else's kild.
+  const sent = await runCli(['send', 'kild-other', '--to', 'claude', 'hi'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-scope',
+  });
+  expect(sent.exitCode).toBe(0);
+  expect(drainRequests.map((r) => r.path)).toEqual(['/api/kilds/kild-other/messages']);
+  expect(authHeaders[0]).toBeNull();
   withNoMail();
 });

--- a/engine/src/cli.attached.test.ts
+++ b/engine/src/cli.attached.test.ts
@@ -378,3 +378,45 @@ test('a send to a kild this session is not attached to presents no credential', 
   expect(authHeaders[0]).toBeNull();
   withNoMail();
 });
+
+/**
+ * The silence line. `kild inbox --format claude-stop` IS a Stop hook and must degrade to
+ * silence; every other verb must fail loudly. An unreadable attachment record is the case
+ * that distinguishes them, because swallowing it in `send` posts a message with no
+ * credential — silently unattributed, which is the bug this whole change exists to fix.
+ */
+async function withCorruptRecord(session: string) {
+  await fs.mkdir(path.join(kildHome, 'attached'), { recursive: true });
+  await fs.writeFile(path.join(kildHome, 'attached', `${session}.json`), '{not json');
+}
+
+test('an unreadable record makes `send` fail loudly, never an unattributed send', async () => {
+  await withCorruptRecord('sess-corrupt');
+  drainResponse = { status: 200, body: { ok: true, message: 'Sent to the kild.' } };
+  drainRequests = [];
+  const sent = await runCli(['send', 'kild-9', '--to', 'claude', 'hi'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-corrupt',
+  });
+  expect(sent.exitCode).toBe(1);
+  expect(sent.stderr).toContain('unreadable attachment record');
+  // The decisive assertion: the message must NOT have gone out without a credential.
+  expect(drainRequests.map((r) => r.path)).not.toContain('/api/kilds/kild-9/messages');
+  withNoMail();
+});
+
+test('the same unreadable record is silence for the hook, which may never block a turn', async () => {
+  await withCorruptRecord('sess-corrupt');
+  const hook = await runCli(['inbox', '--format', 'claude-stop'], undefined, {
+    CLAUDE_CODE_SESSION_ID: 'sess-corrupt',
+  });
+  expect(hook.stdout).toBe('');
+  expect(hook.exitCode).toBe(0);
+});
+
+test('...but an ordinary `inbox` reports the real cause, not a usage message', async () => {
+  await withCorruptRecord('sess-corrupt');
+  const human = await runCli(['inbox'], undefined, { CLAUDE_CODE_SESSION_ID: 'sess-corrupt' });
+  expect(human.exitCode).toBe(1);
+  expect(human.stderr).toContain('unreadable attachment record');
+  expect(human.stderr).not.toContain('usage: kild inbox');
+});

--- a/engine/src/cli.ts
+++ b/engine/src/cli.ts
@@ -288,9 +288,12 @@ async function resolveAttachment(
 ): Promise<{ kildId?: string; handle?: string }> {
   if (id && handle) return { kildId: id, handle };
   const session = harnessSession();
-  // A record that cannot be read is not an error here: this resolution sits under a turn-end
-  // hook, which must degrade to silence rather than fail somebody's every turn.
-  const record = session ? await findAttachment(session).catch(() => null) : null;
+  // Deliberately NOT guarded. An unreadable record means "there may be an attachment and I
+  // cannot read it", and a `kild send` that swallowed that would post the message with no
+  // credential — silently unattributed, which is the exact bug this file exists to fix. The
+  // one caller allowed to degrade to silence is the turn-end hook, and it does so at its own
+  // call site where it knows it is a hook.
+  const record = session ? await findAttachment(session) : null;
   return {
     kildId: id ?? record?.kildId ?? process.env.KILD_KILD_ID ?? undefined,
     handle: handle ?? record?.handle ?? process.env.KILD_HANDLE ?? undefined,
@@ -332,7 +335,18 @@ async function kildInbox(idArg: string | undefined): Promise<void> {
   // Omitting both resolves the kild this session attached to — the case the environment
   // could never serve, since a session that started before the kild existed has no way to
   // be told about it.
-  const { kildId: id, handle } = await resolveAttachment(idArg, values.as);
+  //
+  // This is the one place the hook contract applies: as a hook, an unresolvable or unreadable
+  // attachment is silence; as an ordinary verb it is a loud error naming the real cause, not a
+  // usage message that sends the operator looking at their own syntax.
+  let resolved: { kildId?: string; handle?: string };
+  try {
+    resolved = await resolveAttachment(idArg, values.as);
+  } catch (err) {
+    if (!claudeStop) throw err;
+    return;
+  }
+  const { kildId: id, handle } = resolved;
   if (!id || !handle) {
     if (claudeStop) return; // not attached → silence, never a blocked turn
     throw new Error(

--- a/engine/src/cli.ts
+++ b/engine/src/cli.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
+import { findAttachment, recordAttachment } from './kild/attachment.ts';
 import { claudeStopOutput } from './kild/claude-stop.ts';
 import {
   attachAgent,
@@ -54,6 +55,7 @@ const { values, positionals } = parseArgs({
     since: { type: 'string' }, // `kild log --since <seq>`: only messages after that cursor
     execute: { type: 'boolean', default: false }, // `kild land --execute`: merge for real
     task: { type: 'string' }, // `kild spawn --task <text>`: the new agent's first message
+    session: { type: 'string' }, // `kild attach|inbox|send --session <id>`: the harness session
   },
 });
 
@@ -245,13 +247,72 @@ async function kildCwd(): Promise<string> {
   return (await resolveProjectFlag()) ?? process.cwd();
 }
 
+/**
+ * The harness session this invocation belongs to, when it belongs to one.
+ *
+ * `--session` wins so a harness that knows its own id can say so outright; otherwise take
+ * the one Claude Code exports to the tools it runs. A plain human's shell has neither and
+ * is simply not a harness session, which is correct.
+ *
+ * A `function` declaration, not a `const` arrow: `dispatch()` runs at the top of this
+ * module, so anything it reaches has to be hoisted or it is still in the temporal dead zone
+ * when the first command calls it.
+ */
+function harnessSession(): string | undefined {
+  return values.session ?? process.env.CLAUDE_CODE_SESSION_ID ?? undefined;
+}
+
+/**
+ * The (kild, handle) this invocation acts as, resolved field by field:
+ * **an explicit argument, then this session's recorded attachment, then the environment.**
+ *
+ * The record outranks the environment, which is the opposite of what it looks like it should
+ * be, and the reason is worth keeping: an environment variable here is ambient configuration
+ * that nobody re-reads, while a record exists only because THIS session ran `kild attach` —
+ * a deliberate, recent act naming a kild that existed at the time. When the two disagree, the
+ * deliberate act is the truer one.
+ *
+ * It is also the only ordering that survives the trap this was found in. A harness's settings
+ * file can carry a kild id, that file is re-read on every start including resumes, and it
+ * outranks anything a shell exports — so a stale entry pointing at an ARCHIVED kild is
+ * invisible, unkillable from the shell, and drains nothing forever while reporting success.
+ * Ranking it below an actual attach means a real attach always wins, and the stale value can
+ * only ever be a fallback for a session that never attached at all.
+ *
+ * Pinning up front still works, which was the point of keeping the environment at all. Fields
+ * resolve independently, so a hook that passes `--as` and lets the id resolve works too.
+ */
+async function resolveAttachment(
+  id: string | undefined,
+  handle: string | undefined,
+): Promise<{ kildId?: string; handle?: string }> {
+  if (id && handle) return { kildId: id, handle };
+  const session = harnessSession();
+  // A record that cannot be read is not an error here: this resolution sits under a turn-end
+  // hook, which must degrade to silence rather than fail somebody's every turn.
+  const record = session ? await findAttachment(session).catch(() => null) : null;
+  return {
+    kildId: id ?? record?.kildId ?? process.env.KILD_KILD_ID ?? undefined,
+    handle: handle ?? record?.handle ?? process.env.KILD_HANDLE ?? undefined,
+  };
+}
+
 /** `kild attach <id> --as <handle>` — register an ATTACHED agent: a harness kild
  *  does not own (the Claude Code session you are driving) claiming a `@handle` in the
- *  kild. Nothing is spawned; the handle is addressable immediately. Idempotent. */
+ *  kild. Nothing is spawned; the handle is addressable immediately. Idempotent.
+ *
+ *  The attachment is also recorded against this session's own id, which is what lets the
+ *  session find its handle again later without carrying it in the environment. That is the
+ *  whole of what makes attaching mid-session work: a process's environment is fixed at exec
+ *  time, so a session opened before the kild existed can never be told about it any other
+ *  way. The token is deliberately NOT recorded — it dies with the engine, so a copy on disk
+ *  would go stale and be rejected; `send` mints a fresh one from the idempotent attach. */
 async function kildAttach(id: string | undefined): Promise<void> {
   const handle = values.as;
   if (!id || !handle) throw new Error('usage: kild attach <id> --as <handle>');
   const result = await attachAgent(id, handle);
+  const session = harnessSession();
+  if (session) await recordAttachment(session, id, handle);
   console.log(json ? JSON.stringify(result, null, 2) : result.message);
 }
 
@@ -266,12 +327,18 @@ async function kildAttach(id: string | undefined): Promise<void> {
  * never stop the operator from finishing a turn. Without the flag it is an ordinary CLI
  * verb and failures are ordinary loud errors.
  */
-async function kildInbox(id: string | undefined): Promise<void> {
+async function kildInbox(idArg: string | undefined): Promise<void> {
   const claudeStop = values.format === 'claude-stop';
-  const handle = values.as;
+  // Omitting both resolves the kild this session attached to — the case the environment
+  // could never serve, since a session that started before the kild existed has no way to
+  // be told about it.
+  const { kildId: id, handle } = await resolveAttachment(idArg, values.as);
   if (!id || !handle) {
-    if (claudeStop) return; // misconfigured hook → silence, never a blocked turn
-    throw new Error('usage: kild inbox <id> --as <handle> [--format claude-stop]');
+    if (claudeStop) return; // not attached → silence, never a blocked turn
+    throw new Error(
+      'usage: kild inbox [<id> --as <handle>] [--session <id>] [--format claude-stop]\n' +
+        '  omit id/--as to use the kild this session attached to',
+    );
   }
   if (values.format !== undefined && !claudeStop) {
     throw new Error(`unknown --format: ${values.format} (supported: claude-stop)`);
@@ -547,9 +614,36 @@ async function kildSend(id: string, text: string): Promise<void> {
       `kild ${id}`,
     );
   }
-  const res = await sendMessage(id, to, text);
+  const res = await sendMessage(id, to, text, undefined, await attachedSendToken(id));
   if (json) console.log(JSON.stringify(res, null, 2));
   else console.error(res.message);
+}
+
+/**
+ * The attached-harness credential for a send, when this invocation is one.
+ *
+ * Without it an attached sender presents nothing and lands on the log as the unattributed
+ * label — indistinguishable from the operator typing, and from every other attached agent in
+ * the kild. That is the whole bug: the engine has minted this credential at `attach` all
+ * along and the CLI threw it away.
+ *
+ * Three cases produce no token, all of them correct:
+ *  - an agent the engine SPAWNED — it proves itself with `KILD_AGENT_ID`, and the engine sets
+ *    `KILD_KILD_ID`/`KILD_HANDLE` on it too, so without this guard a spawned agent would
+ *    attach a second, shadow copy of itself over its own handle;
+ *  - a send to any kild other than the one this session attached to — a handle is unique
+ *    within one kild and means nothing outside it, so there is no identity to present;
+ *  - a plain human's shell, which has no attachment at all.
+ *
+ * Minting is not guarded: if we resolved a handle for this very kild and `attach` then fails,
+ * that is a real failure to report. Falling back to sending unattributed would silently
+ * reintroduce the bug at exactly the moment it matters.
+ */
+async function attachedSendToken(kildId: string): Promise<string | undefined> {
+  if (process.env.KILD_AGENT_ID) return undefined;
+  const { kildId: attachedTo, handle } = await resolveAttachment(undefined, values.as);
+  if (!handle || attachedTo !== kildId) return undefined;
+  return (await attachAgent(kildId, handle)).token;
 }
 
 /** `kild stop <id>` — stop a specific kild by id. With `--as <handle>` it stops that ONE

--- a/engine/src/kild/attachment.test.ts
+++ b/engine/src/kild/attachment.test.ts
@@ -75,7 +75,10 @@ describe('supersession — the fork case', () => {
     for (const session of ['s1', 's2', 's3', 's4']) {
       await recordAttachment(session, 'kild-a', 'kild');
     }
-    expect(await fs.readdir(path.join(home, 'attached'))).toEqual(['s4.json']);
+    const records = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
+      f.endsWith('.json'),
+    );
+    expect(records).toEqual(['s4.json']);
   });
 });
 
@@ -107,47 +110,75 @@ describe('unreadable is not the same fact as absent', () => {
   });
 
   test('a record without attachedAt still resolves', async () => {
-    await fs.mkdir(path.join(home, 'attached'), { recursive: true });
+    await fs.mkdir(path.join(home, 'attached', 'claims', 'kild-a'), { recursive: true });
+    await fs.writeFile(path.join(home, 'attached', 'claims', 'kild-a', 'kild'), 's\n');
     await fs.writeFile(recordFile('s'), JSON.stringify({ kildId: 'kild-a', handle: 'kild' }));
     expect(await findAttachment('s')).toMatchObject({ attachedAt: 0 });
+  });
+
+  test('a record nobody claims is not an attachment', async () => {
+    // Only the claim decides who holds a handle. A record with no claim behind it is a
+    // leftover, not a licence to act as that handle.
+    await fs.mkdir(path.join(home, 'attached'), { recursive: true });
+    await fs.writeFile(recordFile('orphan'), JSON.stringify({ kildId: 'k', handle: 'kild' }));
+    expect(await findAttachment('orphan')).toBeNull();
   });
 });
 
 describe('concurrent attaches', () => {
+  /** How many of these sessions consider themselves attached. Exactly one may. */
+  async function resolving(sessions: string[]): Promise<string[]> {
+    const held = await Promise.all(
+      sessions.map(async (s) => ((await findAttachment(s)) ? s : null)),
+    );
+    return held.filter((s): s is string => s !== null);
+  }
+
   test('two sessions claiming one handle at once leave exactly one attached', async () => {
-    // Without mutual exclusion each supersede scan sees the other's freshly written record as
-    // somebody else's and deletes it, leaving NEITHER attached — data loss in precisely the
-    // fork case this record exists to serve.
+    // The scan-and-delete this replaced lost BOTH records here: each saw the other's freshly
+    // written file as somebody else's and deleted it. An atomic claim cannot do that — there
+    // is no intermediate state for a second writer to observe.
     await Promise.all([
       recordAttachment('race-a', 'kild-x', 'claude'),
       recordAttachment('race-b', 'kild-x', 'claude'),
     ]);
-    const survivors = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
-      f.endsWith('.json'),
-    );
-    expect(survivors).toHaveLength(1);
+    expect(await resolving(['race-a', 'race-b'])).toHaveLength(1);
   });
 
   test('many sessions racing on one handle still leave exactly one', async () => {
-    await Promise.all(
-      ['a', 'b', 'c', 'd', 'e', 'f'].map((s) => recordAttachment(`many-${s}`, 'kild-y', 'kild')),
+    const sessions = ['a', 'b', 'c', 'd', 'e', 'f'].map((s) => `many-${s}`);
+    await Promise.all(sessions.map((s) => recordAttachment(s, 'kild-y', 'kild')));
+    expect(await resolving(sessions)).toHaveLength(1);
+  });
+
+  test('the survivor is the one the claim names, and it resolves correctly', async () => {
+    const sessions = ['w-1', 'w-2', 'w-3'];
+    await Promise.all(sessions.map((s) => recordAttachment(s, 'kild-w', 'kild')));
+    const [winner] = await resolving(sessions);
+    expect(winner).toBeDefined();
+    const claim = await fs.readFile(
+      path.join(home, 'attached', 'claims', 'kild-w', 'kild'),
+      'utf8',
     );
-    const survivors = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
-      f.endsWith('.json'),
-    );
-    expect(survivors).toHaveLength(1);
+    expect(claim.trim()).toBe(winner);
+    expect(await findAttachment(winner as string)).toMatchObject({ kildId: 'kild-w' });
   });
 
   test('concurrent attaches to DIFFERENT handles all survive', async () => {
-    await Promise.all([
-      recordAttachment('h-1', 'kild-z', 'alpha'),
-      recordAttachment('h-2', 'kild-z', 'beta'),
-      recordAttachment('h-3', 'kild-z', 'gamma'),
-    ]);
-    const survivors = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
-      f.endsWith('.json'),
-    );
-    expect(survivors).toHaveLength(3);
+    const pairs: Array<[string, string]> = [
+      ['h-1', 'alpha'],
+      ['h-2', 'beta'],
+      ['h-3', 'gamma'],
+    ];
+    await Promise.all(pairs.map(([s, h]) => recordAttachment(s, 'kild-z', h)));
+    expect(await resolving(pairs.map(([s]) => s))).toHaveLength(3);
+  });
+
+  test('a superseded session reads as not attached, never as somebody else', async () => {
+    await recordAttachment('first', 'kild-q', 'kild');
+    await recordAttachment('second', 'kild-q', 'kild');
+    expect(await findAttachment('first')).toBeNull();
+    expect(await findAttachment('second')).toMatchObject({ kildId: 'kild-q', handle: 'kild' });
   });
 });
 

--- a/engine/src/kild/attachment.test.ts
+++ b/engine/src/kild/attachment.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { findAttachment, forgetAttachment, recordAttachment } from './attachment.ts';
+import { findAttachment, recordAttachment } from './attachment.ts';
 
 let home: string;
 let previous: string | undefined;
@@ -79,30 +79,75 @@ describe('supersession — the fork case', () => {
   });
 });
 
-describe('degrading to not-attached', () => {
-  // Every one of these sits under a turn-end hook, which must never fail somebody's turn.
-  test('malformed JSON reads as not attached', async () => {
+describe('unreadable is not the same fact as absent', () => {
+  // A send that swallowed "cannot read" would post with no credential — silently
+  // unattributed, which is the bug this module exists to prevent. Only a missing file means
+  // "not attached"; everything else throws and each caller decides. The turn-end hook
+  // catches at its own call site (see cli.attached.test.ts).
+  test('malformed JSON throws rather than reading as not attached', async () => {
     await fs.mkdir(path.join(home, 'attached'), { recursive: true });
     await fs.writeFile(recordFile('sess-1'), '{not json');
-    expect(await findAttachment('sess-1')).toBeNull();
+    expect(findAttachment('sess-1')).rejects.toThrow('unreadable attachment record');
   });
 
-  test('a record missing its fields reads as not attached', async () => {
+  test('a record missing its fields throws', async () => {
     await fs.mkdir(path.join(home, 'attached'), { recursive: true });
     await fs.writeFile(recordFile('sess-1'), JSON.stringify({ kildId: 'kild-a' }));
-    expect(await findAttachment('sess-1')).toBeNull();
+    expect(findAttachment('sess-1')).rejects.toThrow('malformed attachment record');
   });
 
-  test('a record with non-string fields reads as not attached', async () => {
+  test('a record with non-string fields throws', async () => {
     await fs.mkdir(path.join(home, 'attached'), { recursive: true });
     await fs.writeFile(recordFile('sess-1'), JSON.stringify({ kildId: 1, handle: [] }));
-    expect(await findAttachment('sess-1')).toBeNull();
+    expect(findAttachment('sess-1')).rejects.toThrow('malformed attachment record');
+  });
+
+  test('an absent record is still simply null', async () => {
+    expect(await findAttachment('never-attached')).toBeNull();
   });
 
   test('a record without attachedAt still resolves', async () => {
     await fs.mkdir(path.join(home, 'attached'), { recursive: true });
     await fs.writeFile(recordFile('s'), JSON.stringify({ kildId: 'kild-a', handle: 'kild' }));
     expect(await findAttachment('s')).toMatchObject({ attachedAt: 0 });
+  });
+});
+
+describe('concurrent attaches', () => {
+  test('two sessions claiming one handle at once leave exactly one attached', async () => {
+    // Without mutual exclusion each supersede scan sees the other's freshly written record as
+    // somebody else's and deletes it, leaving NEITHER attached — data loss in precisely the
+    // fork case this record exists to serve.
+    await Promise.all([
+      recordAttachment('race-a', 'kild-x', 'claude'),
+      recordAttachment('race-b', 'kild-x', 'claude'),
+    ]);
+    const survivors = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
+      f.endsWith('.json'),
+    );
+    expect(survivors).toHaveLength(1);
+  });
+
+  test('many sessions racing on one handle still leave exactly one', async () => {
+    await Promise.all(
+      ['a', 'b', 'c', 'd', 'e', 'f'].map((s) => recordAttachment(`many-${s}`, 'kild-y', 'kild')),
+    );
+    const survivors = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
+      f.endsWith('.json'),
+    );
+    expect(survivors).toHaveLength(1);
+  });
+
+  test('concurrent attaches to DIFFERENT handles all survive', async () => {
+    await Promise.all([
+      recordAttachment('h-1', 'kild-z', 'alpha'),
+      recordAttachment('h-2', 'kild-z', 'beta'),
+      recordAttachment('h-3', 'kild-z', 'gamma'),
+    ]);
+    const survivors = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
+      f.endsWith('.json'),
+    );
+    expect(survivors).toHaveLength(3);
   });
 });
 
@@ -120,17 +165,5 @@ describe('session ids reach the filesystem', () => {
   test('a traversing id cannot write outside the directory', async () => {
     await expect(recordAttachment('../../escaped', 'kild-a', 'kild')).rejects.toThrow();
     await expect(fs.readFile(path.join(home, '..', '..', 'escaped.json'))).rejects.toThrow();
-  });
-});
-
-describe('forgetAttachment', () => {
-  test('drops the record', async () => {
-    await recordAttachment('sess-1', 'kild-a', 'kild');
-    await forgetAttachment('sess-1');
-    expect(await findAttachment('sess-1')).toBeNull();
-  });
-
-  test('forgetting a session that never attached is not an error', async () => {
-    await forgetAttachment('never-attached');
   });
 });

--- a/engine/src/kild/attachment.test.ts
+++ b/engine/src/kild/attachment.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { findAttachment, forgetAttachment, recordAttachment } from './attachment.ts';
+
+let home: string;
+let previous: string | undefined;
+
+beforeEach(async () => {
+  previous = process.env.KILD_HOME;
+  // Resolved with realpath: on macOS the temp dir is a symlink (/var → /private/var), and
+  // half the engine's paths come from git already resolved. One spelling, everywhere.
+  home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'kild-attach-')));
+  process.env.KILD_HOME = home;
+});
+
+afterEach(async () => {
+  if (previous === undefined) delete process.env.KILD_HOME;
+  else process.env.KILD_HOME = previous;
+  await fs.rm(home, { recursive: true, force: true });
+});
+
+const recordFile = (session: string) => path.join(home, 'attached', `${session}.json`);
+
+describe('recordAttachment / findAttachment', () => {
+  test('a session finds the kild and handle it attached as', async () => {
+    await recordAttachment('sess-1', 'kild-a', 'kild');
+    expect(await findAttachment('sess-1')).toMatchObject({ kildId: 'kild-a', handle: 'kild' });
+  });
+
+  test('a session that never attached has no attachment', async () => {
+    expect(await findAttachment('never-attached')).toBeNull();
+  });
+
+  test('re-attaching the same session re-points it', async () => {
+    await recordAttachment('sess-1', 'kild-a', 'kild');
+    await recordAttachment('sess-1', 'kild-b', 'helm');
+    expect(await findAttachment('sess-1')).toMatchObject({ kildId: 'kild-b', handle: 'helm' });
+  });
+
+  test('attachedAt is recorded', async () => {
+    const before = Date.now();
+    await recordAttachment('sess-1', 'kild-a', 'kild');
+    const record = await findAttachment('sess-1');
+    expect(record?.attachedAt).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('supersession — the fork case', () => {
+  test('a new session claiming the same handle supersedes the old record', async () => {
+    await recordAttachment('old-session', 'kild-a', 'kild');
+    await recordAttachment('new-session', 'kild-a', 'kild');
+
+    // The fork inherits the handle; the session it forked from must not keep a claim on it,
+    // or two sessions would race on one destructive inbox.
+    expect(await findAttachment('new-session')).toMatchObject({ kildId: 'kild-a' });
+    expect(await findAttachment('old-session')).toBeNull();
+  });
+
+  test('a different handle in the same kild is left alone', async () => {
+    await recordAttachment('sess-other', 'kild-a', 'helm');
+    await recordAttachment('sess-mine', 'kild-a', 'kild');
+    expect(await findAttachment('sess-other')).toMatchObject({ handle: 'helm' });
+  });
+
+  test('the same handle in a different kild is left alone', async () => {
+    await recordAttachment('sess-other', 'kild-b', 'kild');
+    await recordAttachment('sess-mine', 'kild-a', 'kild');
+    expect(await findAttachment('sess-other')).toMatchObject({ kildId: 'kild-b' });
+  });
+
+  test('forks do not accumulate records', async () => {
+    for (const session of ['s1', 's2', 's3', 's4']) {
+      await recordAttachment(session, 'kild-a', 'kild');
+    }
+    expect(await fs.readdir(path.join(home, 'attached'))).toEqual(['s4.json']);
+  });
+});
+
+describe('degrading to not-attached', () => {
+  // Every one of these sits under a turn-end hook, which must never fail somebody's turn.
+  test('malformed JSON reads as not attached', async () => {
+    await fs.mkdir(path.join(home, 'attached'), { recursive: true });
+    await fs.writeFile(recordFile('sess-1'), '{not json');
+    expect(await findAttachment('sess-1')).toBeNull();
+  });
+
+  test('a record missing its fields reads as not attached', async () => {
+    await fs.mkdir(path.join(home, 'attached'), { recursive: true });
+    await fs.writeFile(recordFile('sess-1'), JSON.stringify({ kildId: 'kild-a' }));
+    expect(await findAttachment('sess-1')).toBeNull();
+  });
+
+  test('a record with non-string fields reads as not attached', async () => {
+    await fs.mkdir(path.join(home, 'attached'), { recursive: true });
+    await fs.writeFile(recordFile('sess-1'), JSON.stringify({ kildId: 1, handle: [] }));
+    expect(await findAttachment('sess-1')).toBeNull();
+  });
+
+  test('a record without attachedAt still resolves', async () => {
+    await fs.mkdir(path.join(home, 'attached'), { recursive: true });
+    await fs.writeFile(recordFile('s'), JSON.stringify({ kildId: 'kild-a', handle: 'kild' }));
+    expect(await findAttachment('s')).toMatchObject({ attachedAt: 0 });
+  });
+});
+
+describe('session ids reach the filesystem', () => {
+  test.each([
+    ['../escape', 'traversal'],
+    ['a/b', 'separator'],
+    ['', 'empty'],
+    ['sess$(whoami)', 'shell metacharacters'],
+  ])('%s is refused (%s)', async (session) => {
+    expect(recordAttachment(session, 'kild-a', 'kild')).rejects.toThrow('invalid session id');
+    expect(findAttachment(session)).rejects.toThrow('invalid session id');
+  });
+
+  test('a traversing id cannot write outside the directory', async () => {
+    await expect(recordAttachment('../../escaped', 'kild-a', 'kild')).rejects.toThrow();
+    await expect(fs.readFile(path.join(home, '..', '..', 'escaped.json'))).rejects.toThrow();
+  });
+});
+
+describe('forgetAttachment', () => {
+  test('drops the record', async () => {
+    await recordAttachment('sess-1', 'kild-a', 'kild');
+    await forgetAttachment('sess-1');
+    expect(await findAttachment('sess-1')).toBeNull();
+  });
+
+  test('forgetting a session that never attached is not an error', async () => {
+    await forgetAttachment('never-attached');
+  });
+});

--- a/engine/src/kild/attachment.test.ts
+++ b/engine/src/kild/attachment.test.ts
@@ -71,14 +71,15 @@ describe('supersession — the fork case', () => {
     expect(await findAttachment('sess-other')).toMatchObject({ kildId: 'kild-b' });
   });
 
-  test('forks do not accumulate records', async () => {
-    for (const session of ['s1', 's2', 's3', 's4']) {
-      await recordAttachment(session, 'kild-a', 'kild');
+  test('only the newest fork resolves, however many came before it', async () => {
+    const sessions = ['s1', 's2', 's3', 's4'];
+    for (const session of sessions) await recordAttachment(session, 'kild-a', 'kild');
+    // Their records are all still on disk — deleting them cannot be made race-free and is not
+    // what makes this correct. The claim is: exactly one session resolves.
+    for (const stale of sessions.slice(0, -1)) {
+      expect(await findAttachment(stale)).toBeNull();
     }
-    const records = (await fs.readdir(path.join(home, 'attached'))).filter((f) =>
-      f.endsWith('.json'),
-    );
-    expect(records).toEqual(['s4.json']);
+    expect(await findAttachment('s4')).toMatchObject({ kildId: 'kild-a', handle: 'kild' });
   });
 });
 
@@ -196,5 +197,38 @@ describe('session ids reach the filesystem', () => {
   test('a traversing id cannot write outside the directory', async () => {
     await expect(recordAttachment('../../escaped', 'kild-a', 'kild')).rejects.toThrow();
     await expect(fs.readFile(path.join(home, '..', '..', 'escaped.json'))).rejects.toThrow();
+  });
+});
+
+describe('path segments cannot escape the directory', () => {
+  test.each([
+    ['..', 'traversal token'],
+    ['.', 'current directory'],
+  ])('a handle of %s is refused (%s)', async (handle) => {
+    // `path.join` collapses `..` against the segment before it, so this would target the
+    // shared claims DIRECTORY rather than a file in it — turning it into a plain file and
+    // breaking every later attach with ENOTDIR, permanently.
+    expect(recordAttachment('sess', 'kild-a', handle)).rejects.toThrow('invalid handle');
+  });
+
+  test.each([
+    ['..', 'traversal token'],
+    ['.', 'current directory'],
+  ])('a kild id of %s is refused (%s)', async (kildId) => {
+    expect(recordAttachment('sess', kildId, 'kild')).rejects.toThrow('invalid kild id');
+  });
+
+  test('a rejected segment leaves the claims directory intact', async () => {
+    await recordAttachment('good', 'kild-real', 'kild');
+    await expect(recordAttachment('sess', 'kild-a', '..')).rejects.toThrow();
+    // The decisive check: a normal attach still works afterwards.
+    await recordAttachment('after', 'kild-other', 'kild');
+    expect(await findAttachment('after')).toMatchObject({ kildId: 'kild-other' });
+    expect(await findAttachment('good')).toMatchObject({ kildId: 'kild-real' });
+  });
+
+  test('dots are still allowed INSIDE a value', async () => {
+    await recordAttachment('sess.1', 'kild.v1.2', 'agent.one');
+    expect(await findAttachment('sess.1')).toMatchObject({ kildId: 'kild.v1.2' });
   });
 });

--- a/engine/src/kild/attachment.ts
+++ b/engine/src/kild/attachment.ts
@@ -63,7 +63,15 @@ function attachmentsDir(): string {
  * gets a loud error here, not a write to somewhere else.
  */
 function safeSegment(kind: string, value: string): string {
-  if (!/^[A-Za-z0-9._-]+$/.test(value)) throw new Error(`invalid ${kind}: ${value}`);
+  // `.` is allowed inside a value (worktree names carry dots), which means the character
+  // class alone lets `.` and `..` through whole — and `path.join` then collapses `..` against
+  // the segment before it, so `<kild>/..` resolves to the shared `claims` directory itself
+  // rather than to a file in it. One such write turns that directory into a plain file and
+  // every later attach fails with ENOTDIR, permanently. Blocking `/` is not enough; the
+  // traversal tokens have to go too.
+  if (value === '.' || value === '..' || !/^[A-Za-z0-9._-]+$/.test(value)) {
+    throw new Error(`invalid ${kind}: ${value}`);
+  }
   return value;
 }
 
@@ -149,7 +157,6 @@ export async function recordAttachment(
   await writeAtomic(claim, `${session}\n`);
   const record: Attachment = { kildId, handle, attachedAt: Date.now() };
   await writeAtomic(file, `${JSON.stringify(record)}\n`);
-  await sweepSuperseded();
 }
 
 /** Write via a unique temp file in the same directory, then rename over the target. Same
@@ -167,43 +174,20 @@ async function writeAtomic(file: string, contents: string): Promise<void> {
 }
 
 /**
- * Delete session records whose handle is now claimed by somebody else.
+ * Records of superseded sessions are NOT deleted, and that is deliberate.
  *
- * Bounded growth, nothing more: without it a forked session leaves an inert record behind on
- * every relaunch. It is safe to run concurrently with any other attach because it only
- * removes records that ALREADY resolve to null — the claim is the single source of truth, and
- * a record the claim does not name is not an attachment whichever way the race went.
+ * A sweep used to run here to bound growth. It could not be made safe: it decided from a
+ * snapshot it had already read but unlinked the live path, so an ordinary re-attach racing
+ * any other session's sweep deleted a record whose claim still named it — leaving a session
+ * holding a claim with no record, which resolves to "not attached", which makes the next send
+ * go out with no credential. That is the exact failure this module exists to prevent, so a
+ * disk-tidiness pass is not worth reaching for it.
  *
- * Failures are reported, not swallowed, but are not fatal: the attachment itself is complete
- * before this runs, and a record left behind costs disk, never a wrong answer.
+ * Leaving them costs one small inert file per forked session. Nothing scans this directory —
+ * every read is a direct path lookup — so the cost is bytes and never latency or a wrong
+ * answer. If it ever needs reclaiming, that belongs in an explicit maintenance verb the
+ * operator runs, not in an implicit delete on somebody else's attach.
  */
-async function sweepSuperseded(): Promise<void> {
-  const dir = attachmentsDir();
-  let entries: string[];
-  try {
-    entries = await fs.readdir(dir);
-  } catch (err) {
-    console.error(`kild: could not tidy ${dir}: ${(err as Error).message}`);
-    return;
-  }
-  await Promise.all(
-    entries
-      .filter((entry) => entry.endsWith('.json'))
-      .map(async (entry) => {
-        const file = path.join(dir, entry);
-        try {
-          const record = await readRecord(file);
-          if (!record) return;
-          const owner = await readClaim(record.kildId, record.handle);
-          if (owner !== null && owner !== path.basename(entry, '.json')) {
-            await fs.rm(file, { force: true });
-          }
-        } catch (err) {
-          console.error(`kild: could not tidy ${file}: ${(err as Error).message}`);
-        }
-      }),
-  );
-}
 
 /**
  * The session's attachment, or null when it has none.

--- a/engine/src/kild/attachment.ts
+++ b/engine/src/kild/attachment.ts
@@ -11,18 +11,17 @@ import { kildHome } from './config.ts';
  * the harness process's environment. A process's environment is fixed at exec time, so a
  * session could not attach to a kild opened *after* it started — the normal case, since you
  * decide to delegate mid-session. `export` in a tool call changes a child shell, never the
- * harness, so the only remedy was relaunching from a prepared shell. Worse, a resumed or
- * forked session rebuilds its environment from the original session's, so for those there is
- * no shell whose environment reaches the process at all.
+ * harness. Worse, a resumed or forked session rebuilds its environment from a harness
+ * settings file no shell owns, so for those there is nothing a shell can do at all.
  *
  * Keyed by the harness's own session id — an opaque string kild stores and hands back. Only
  * the hook script knows where that id comes from; the engine learns nothing about any
  * harness here, which is what keeps this on kild's side of the boundary.
  *
  * What is NOT here: the attach token. It is minted in memory and dies with the engine
- * ({@link ../kild/attach-token.ts}), so a copy on disk would outlive the thing it names and
- * be rejected as unknown on the next send. The token is fetched at call time from the
- * idempotent `attach` instead, which is always fresh and needs no secret on disk.
+ * (`attach-token.ts`), so a copy on disk would outlive the thing it names and be rejected as
+ * unknown on the next send. The token is fetched at call time from the idempotent `attach`
+ * instead, which is always fresh and needs no secret on disk.
  */
 export interface Attachment {
   /** The kild this session holds a handle in. */
@@ -49,23 +48,90 @@ function recordPath(session: string): string {
   return path.join(attachmentsDir(), `${session}.json`);
 }
 
+/**
+ * Read one record. **Absent is null; anything else throws.**
+ *
+ * Only "no such file" means *not attached*. A permission error, an I/O error or a corrupt
+ * record all mean "there may be an attachment and I cannot read it", which is a different
+ * fact and must not be flattened into the first one. This primitive reports what it found
+ * and lets each caller decide: the turn-end hook degrades to silence, and `kild send` fails
+ * loudly rather than posting a message with no credential.
+ *
+ * Flattening them is how the original bug worked — a send that silently lost its attribution
+ * looked exactly like a successful one.
+ */
 async function readRecord(file: string): Promise<Attachment | null> {
   let raw: string;
   try {
     raw = await fs.readFile(file, 'utf8');
-  } catch {
-    return null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+  let parsed: Partial<Attachment>;
+  try {
+    parsed = JSON.parse(raw) as Partial<Attachment>;
+  } catch (err) {
+    throw new Error(`unreadable attachment record ${file}: ${(err as Error).message}`);
+  }
+  if (typeof parsed.kildId !== 'string' || typeof parsed.handle !== 'string') {
+    throw new Error(`malformed attachment record ${file}: kildId and handle are required`);
+  }
+  return {
+    kildId: parsed.kildId,
+    handle: parsed.handle,
+    attachedAt: typeof parsed.attachedAt === 'number' ? parsed.attachedAt : 0,
+  };
+}
+
+/** How long to wait for another attach to finish before treating its lock as abandoned.
+ *  Attaching is one small write and a scan of a handful of files, so a lock still held after
+ *  this long is a crashed process, not a slow one. */
+const LOCK_STALE_MS = 5_000;
+const LOCK_POLL_MS = 25;
+
+/**
+ * Run `fn` with exclusive access to the attachments directory.
+ *
+ * `mkdir` is atomic and fails with EEXIST when the directory is already there, which makes it
+ * the smallest mutual exclusion available without a dependency. It is needed because
+ * superseding is a read-modify-write over a shared directory: two sessions attaching to the
+ * same (kild, handle) at once would each scan, each see the other's freshly written record as
+ * "somebody else's", and each delete it — leaving NEITHER session attached rather than the
+ * last one. That is data loss, and it is the fork case this whole record exists to serve.
+ *
+ * Failing to acquire is not fatal. The record itself is written under the lock either way;
+ * only superseding is skipped, and it says so. A wedged lock must never stop an operator
+ * attaching.
+ */
+async function withLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  const lock = path.join(attachmentsDir(), '.lock');
+  const deadline = Date.now() + LOCK_STALE_MS;
+  for (;;) {
+    try {
+      await fs.mkdir(lock);
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      if (Date.now() >= deadline) {
+        // Break a lock this old rather than spin forever, then take it ourselves. If that
+        // race is lost too, give up loudly instead of looping.
+        await fs.rm(lock, { recursive: true, force: true });
+        try {
+          await fs.mkdir(lock);
+          break;
+        } catch {
+          console.error(`kild: could not lock ${attachmentsDir()}; skipped superseding`);
+          return undefined;
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+    }
   }
   try {
-    const parsed = JSON.parse(raw) as Partial<Attachment>;
-    if (typeof parsed.kildId !== 'string' || typeof parsed.handle !== 'string') return null;
-    return {
-      kildId: parsed.kildId,
-      handle: parsed.handle,
-      attachedAt: typeof parsed.attachedAt === 'number' ? parsed.attachedAt : 0,
-    };
-  } catch {
-    return null;
+    return await fn();
+  } finally {
+    await fs.rm(lock, { recursive: true, force: true });
   }
 }
 
@@ -74,10 +140,10 @@ async function readRecord(file: string): Promise<Attachment | null> {
  * the same (kild, handle).
  *
  * Superseding is not tidiness. A session id is not stable: `--resume`/`--fork-session` mints
- * a new one for what the operator experiences as the same session, so without this every
- * fork would leave an orphan record behind and the directory would grow one entry per
- * relaunch. And a handle is one identity — two live sessions sharing it would race on the
- * same inbox, each destructively draining mail meant for the other. Last attach wins.
+ * a new one for what the operator experiences as the same session, so without this every fork
+ * leaves an orphan record and the directory grows one entry per relaunch. And a handle is one
+ * identity — two live sessions sharing it would race on one destructive inbox, each eating
+ * mail meant for the other. Last attach wins.
  */
 export async function recordAttachment(
   session: string,
@@ -86,30 +152,48 @@ export async function recordAttachment(
 ): Promise<void> {
   const file = recordPath(session);
   await fs.mkdir(path.dirname(file), { recursive: true });
-  const record: Attachment = { kildId, handle, attachedAt: Date.now() };
-  await fs.writeFile(file, `${JSON.stringify(record)}\n`);
-  await supersede(file, kildId, handle);
+  await withLock(async () => {
+    const record: Attachment = { kildId, handle, attachedAt: Date.now() };
+    await fs.writeFile(file, `${JSON.stringify(record)}\n`);
+    await supersede(file, kildId, handle);
+  });
 }
 
-/** Drop every OTHER session's record of this (kild, handle). Failure to enumerate is not
- *  fatal — the record we just wrote is the one that matters, and a leftover sibling costs a
- *  stale entry, never a wrong answer for the session that just attached. */
+/**
+ * Drop every OTHER session's record of this (kild, handle). Runs under the lock.
+ *
+ * Not fatal to the attach that just succeeded — its own record is written and correct. But it
+ * is not nothing either: superseding is what backs "two sessions can never race on one
+ * destructive inbox", so a failure means that guarantee quietly does not hold. Each failure is
+ * REPORTED rather than swallowed; the attach stands, and the operator is told a stale sibling
+ * may have survived it.
+ */
 async function supersede(keep: string, kildId: string, handle: string): Promise<void> {
+  const dir = attachmentsDir();
   let entries: string[];
   try {
-    entries = await fs.readdir(attachmentsDir());
-  } catch {
+    entries = await fs.readdir(dir);
+  } catch (err) {
+    console.error(
+      `kild: could not check ${dir} for other sessions holding @${handle}: ${(err as Error).message}`,
+    );
     return;
   }
   await Promise.all(
     entries
       .filter((entry) => entry.endsWith('.json'))
       .map(async (entry) => {
-        const file = path.join(attachmentsDir(), entry);
+        const file = path.join(dir, entry);
         if (file === keep) return;
-        const record = await readRecord(file);
-        if (record?.kildId === kildId && record.handle === handle) {
-          await fs.rm(file, { force: true });
+        // One unreadable sibling must not fail the attach, but it is exactly the case where a
+        // duplicate claim could survive unseen — so say so instead of skipping in silence.
+        try {
+          const record = await readRecord(file);
+          if (record?.kildId === kildId && record.handle === handle) {
+            await fs.rm(file, { force: true });
+          }
+        } catch (err) {
+          console.error(`kild: could not supersede ${file}: ${(err as Error).message}`);
         }
       }),
   );
@@ -118,16 +202,10 @@ async function supersede(keep: string, kildId: string, handle: string): Promise<
 /**
  * The session's attachment, or null when it has none.
  *
- * Unreadable, malformed, and absent all read as "not attached". This is the property that
- * makes it safe to call from a turn-end hook: a hook must degrade to silence, and a dead key
- * left behind by a fork must not become an error on somebody's every turn.
+ * Only *absent* is null. Anything that means "there may be an attachment and I cannot read
+ * it" throws, so a caller that must not act on a guess does not get one. The turn-end hook
+ * catches and degrades to silence; `kild send` lets it through and fails.
  */
 export async function findAttachment(session: string): Promise<Attachment | null> {
   return readRecord(recordPath(session));
-}
-
-/** Drop a session's record. Used when its kild stops, so a stale id cannot point a later
- *  session at a kild that is gone. */
-export async function forgetAttachment(session: string): Promise<void> {
-  await fs.rm(recordPath(session), { force: true });
 }

--- a/engine/src/kild/attachment.ts
+++ b/engine/src/kild/attachment.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { kildHome } from './config.ts';
+
+/**
+ * Which kild a harness session attached to, recorded so the session can find its own handle
+ * again without being told.
+ *
+ * The problem this removes: an attached agent was reachable only if `KILD_KILD_ID` was in
+ * the harness process's environment. A process's environment is fixed at exec time, so a
+ * session could not attach to a kild opened *after* it started — the normal case, since you
+ * decide to delegate mid-session. `export` in a tool call changes a child shell, never the
+ * harness, so the only remedy was relaunching from a prepared shell. Worse, a resumed or
+ * forked session rebuilds its environment from the original session's, so for those there is
+ * no shell whose environment reaches the process at all.
+ *
+ * Keyed by the harness's own session id — an opaque string kild stores and hands back. Only
+ * the hook script knows where that id comes from; the engine learns nothing about any
+ * harness here, which is what keeps this on kild's side of the boundary.
+ *
+ * What is NOT here: the attach token. It is minted in memory and dies with the engine
+ * ({@link ../kild/attach-token.ts}), so a copy on disk would outlive the thing it names and
+ * be rejected as unknown on the next send. The token is fetched at call time from the
+ * idempotent `attach` instead, which is always fresh and needs no secret on disk.
+ */
+export interface Attachment {
+  /** The kild this session holds a handle in. */
+  kildId: string;
+  /** The handle claimed — what other agents address, and what `to[]` names. */
+  handle: string;
+  /** Epoch ms. Recorded for diagnosis; nothing expires on it. */
+  attachedAt: number;
+}
+
+function attachmentsDir(): string {
+  return path.join(kildHome(), 'attached');
+}
+
+/**
+ * Session ids reach the filesystem as filenames, so anything that is not a plain handle is
+ * refused rather than allowed to walk out of the directory with `../`. A harness that
+ * reports an exotic id gets a loud error here, not a write to somewhere else.
+ */
+function recordPath(session: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(session)) {
+    throw new Error(`invalid session id: ${session}`);
+  }
+  return path.join(attachmentsDir(), `${session}.json`);
+}
+
+async function readRecord(file: string): Promise<Attachment | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<Attachment>;
+    if (typeof parsed.kildId !== 'string' || typeof parsed.handle !== 'string') return null;
+    return {
+      kildId: parsed.kildId,
+      handle: parsed.handle,
+      attachedAt: typeof parsed.attachedAt === 'number' ? parsed.attachedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record (or re-point) a session's attachment, and **supersede** any other session holding
+ * the same (kild, handle).
+ *
+ * Superseding is not tidiness. A session id is not stable: `--resume`/`--fork-session` mints
+ * a new one for what the operator experiences as the same session, so without this every
+ * fork would leave an orphan record behind and the directory would grow one entry per
+ * relaunch. And a handle is one identity — two live sessions sharing it would race on the
+ * same inbox, each destructively draining mail meant for the other. Last attach wins.
+ */
+export async function recordAttachment(
+  session: string,
+  kildId: string,
+  handle: string,
+): Promise<void> {
+  const file = recordPath(session);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const record: Attachment = { kildId, handle, attachedAt: Date.now() };
+  await fs.writeFile(file, `${JSON.stringify(record)}\n`);
+  await supersede(file, kildId, handle);
+}
+
+/** Drop every OTHER session's record of this (kild, handle). Failure to enumerate is not
+ *  fatal — the record we just wrote is the one that matters, and a leftover sibling costs a
+ *  stale entry, never a wrong answer for the session that just attached. */
+async function supersede(keep: string, kildId: string, handle: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(attachmentsDir());
+  } catch {
+    return;
+  }
+  await Promise.all(
+    entries
+      .filter((entry) => entry.endsWith('.json'))
+      .map(async (entry) => {
+        const file = path.join(attachmentsDir(), entry);
+        if (file === keep) return;
+        const record = await readRecord(file);
+        if (record?.kildId === kildId && record.handle === handle) {
+          await fs.rm(file, { force: true });
+        }
+      }),
+  );
+}
+
+/**
+ * The session's attachment, or null when it has none.
+ *
+ * Unreadable, malformed, and absent all read as "not attached". This is the property that
+ * makes it safe to call from a turn-end hook: a hook must degrade to silence, and a dead key
+ * left behind by a fork must not become an error on somebody's every turn.
+ */
+export async function findAttachment(session: string): Promise<Attachment | null> {
+  return readRecord(recordPath(session));
+}
+
+/** Drop a session's record. Used when its kild stops, so a stale id cannot point a later
+ *  session at a kild that is gone. */
+export async function forgetAttachment(session: string): Promise<void> {
+  await fs.rm(recordPath(session), { force: true });
+}

--- a/engine/src/kild/attachment.ts
+++ b/engine/src/kild/attachment.ts
@@ -22,6 +22,27 @@ import { kildHome } from './config.ts';
  * (`attach-token.ts`), so a copy on disk would outlive the thing it names and be rejected as
  * unknown on the next send. The token is fetched at call time from the idempotent `attach`
  * instead, which is always fresh and needs no secret on disk.
+ *
+ * ## Two files, because a handle is one identity
+ *
+ * A handle is held by exactly one session: two sessions sharing one would race on a
+ * destructive inbox, each eating mail meant for the other. And session ids are not stable —
+ * `--resume`/`--fork-session` mints a new one for what the operator experiences as the same
+ * session — so "who holds this handle" changes and must have a single answer at all times.
+ *
+ *   `attached/<session>.json`            what this session attached to
+ *   `attached/claims/<kild>/<handle>`    which session currently holds that handle
+ *
+ * The claim is written by **atomic rename**, so concurrent attaches to one handle resolve to
+ * exactly one winner with no lock, no timeout and no staleness heuristic — the last rename
+ * wins and no intermediate state is ever observable. A session resolves only if the claim
+ * still names it.
+ *
+ * The obvious alternative — one file per session plus a scan that deletes the others — is
+ * what this replaced. It is a read-modify-write over a shared directory: two sessions each
+ * saw the other's freshly written record as somebody else's and deleted it, leaving NEITHER
+ * attached. Guarding it with a lock re-introduced timing questions (how old is too old, who
+ * owns the lock, what if acquisition fails) that an atomic rename simply does not raise.
  */
 export interface Attachment {
   /** The kild this session holds a handle in. */
@@ -37,15 +58,28 @@ function attachmentsDir(): string {
 }
 
 /**
- * Session ids reach the filesystem as filenames, so anything that is not a plain handle is
- * refused rather than allowed to walk out of the directory with `../`. A harness that
- * reports an exotic id gets a loud error here, not a write to somewhere else.
+ * These strings become path segments, so anything that is not a plain token is refused rather
+ * than allowed to walk out of the directory with `../`. A caller that supplies an exotic id
+ * gets a loud error here, not a write to somewhere else.
  */
+function safeSegment(kind: string, value: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(value)) throw new Error(`invalid ${kind}: ${value}`);
+  return value;
+}
+
 function recordPath(session: string): string {
-  if (!/^[A-Za-z0-9._-]+$/.test(session)) {
-    throw new Error(`invalid session id: ${session}`);
-  }
-  return path.join(attachmentsDir(), `${session}.json`);
+  return path.join(attachmentsDir(), `${safeSegment('session id', session)}.json`);
+}
+
+/** Kild and handle are separate path segments rather than one joined name: a separator
+ *  inside either value could otherwise make two different pairs collide on one filename. */
+function claimPath(kildId: string, handle: string): string {
+  return path.join(
+    attachmentsDir(),
+    'claims',
+    safeSegment('kild id', kildId),
+    safeSegment('handle', handle),
+  );
 }
 
 /**
@@ -84,99 +118,72 @@ async function readRecord(file: string): Promise<Attachment | null> {
   };
 }
 
-/** How long to wait for another attach to finish before treating its lock as abandoned.
- *  Attaching is one small write and a scan of a handful of files, so a lock still held after
- *  this long is a crashed process, not a slow one. */
-const LOCK_STALE_MS = 5_000;
-const LOCK_POLL_MS = 25;
-
-/**
- * Run `fn` with exclusive access to the attachments directory.
- *
- * `mkdir` is atomic and fails with EEXIST when the directory is already there, which makes it
- * the smallest mutual exclusion available without a dependency. It is needed because
- * superseding is a read-modify-write over a shared directory: two sessions attaching to the
- * same (kild, handle) at once would each scan, each see the other's freshly written record as
- * "somebody else's", and each delete it — leaving NEITHER session attached rather than the
- * last one. That is data loss, and it is the fork case this whole record exists to serve.
- *
- * Failing to acquire is not fatal. The record itself is written under the lock either way;
- * only superseding is skipped, and it says so. A wedged lock must never stop an operator
- * attaching.
- */
-async function withLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
-  const lock = path.join(attachmentsDir(), '.lock');
-  const deadline = Date.now() + LOCK_STALE_MS;
-  for (;;) {
-    try {
-      await fs.mkdir(lock);
-      break;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-      if (Date.now() >= deadline) {
-        // Break a lock this old rather than spin forever, then take it ourselves. If that
-        // race is lost too, give up loudly instead of looping.
-        await fs.rm(lock, { recursive: true, force: true });
-        try {
-          await fs.mkdir(lock);
-          break;
-        } catch {
-          console.error(`kild: could not lock ${attachmentsDir()}; skipped superseding`);
-          return undefined;
-        }
-      }
-      await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MS));
-    }
-  }
+/** The session currently holding a handle, or null when nobody does. Absent is the only
+ *  null; an unreadable claim throws, for the same reason an unreadable record does. */
+async function readClaim(kildId: string, handle: string): Promise<string | null> {
   try {
-    return await fn();
-  } finally {
-    await fs.rm(lock, { recursive: true, force: true });
+    return (await fs.readFile(claimPath(kildId, handle), 'utf8')).trim();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
   }
 }
 
 /**
- * Record (or re-point) a session's attachment, and **supersede** any other session holding
- * the same (kild, handle).
+ * Record a session's attachment and claim the handle for it.
  *
- * Superseding is not tidiness. A session id is not stable: `--resume`/`--fork-session` mints
- * a new one for what the operator experiences as the same session, so without this every fork
- * leaves an orphan record and the directory grows one entry per relaunch. And a handle is one
- * identity — two live sessions sharing it would race on one destructive inbox, each eating
- * mail meant for the other. Last attach wins.
+ * The claim is written FIRST, so a crash between the two writes leaves an unreferenced claim
+ * (harmless) rather than a record that resolves against a claim that was never made. Both
+ * writes go through a temp file and `rename`, which is atomic: a reader sees the old content
+ * or the new one, never a half-written file, and concurrent writers produce exactly one
+ * winner without coordinating.
  */
 export async function recordAttachment(
   session: string,
   kildId: string,
   handle: string,
 ): Promise<void> {
+  const claim = claimPath(kildId, handle);
   const file = recordPath(session);
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  await withLock(async () => {
-    const record: Attachment = { kildId, handle, attachedAt: Date.now() };
-    await fs.writeFile(file, `${JSON.stringify(record)}\n`);
-    await supersede(file, kildId, handle);
-  });
+  await fs.mkdir(path.dirname(claim), { recursive: true });
+  await writeAtomic(claim, `${session}\n`);
+  const record: Attachment = { kildId, handle, attachedAt: Date.now() };
+  await writeAtomic(file, `${JSON.stringify(record)}\n`);
+  await sweepSuperseded();
+}
+
+/** Write via a unique temp file in the same directory, then rename over the target. Same
+ *  directory so the rename never crosses a filesystem, and unique so two concurrent writers
+ *  cannot share a temp path. */
+async function writeAtomic(file: string, contents: string): Promise<void> {
+  const temp = `${file}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  await fs.writeFile(temp, contents);
+  try {
+    await fs.rename(temp, file);
+  } catch (err) {
+    await fs.rm(temp, { force: true });
+    throw err;
+  }
 }
 
 /**
- * Drop every OTHER session's record of this (kild, handle). Runs under the lock.
+ * Delete session records whose handle is now claimed by somebody else.
  *
- * Not fatal to the attach that just succeeded — its own record is written and correct. But it
- * is not nothing either: superseding is what backs "two sessions can never race on one
- * destructive inbox", so a failure means that guarantee quietly does not hold. Each failure is
- * REPORTED rather than swallowed; the attach stands, and the operator is told a stale sibling
- * may have survived it.
+ * Bounded growth, nothing more: without it a forked session leaves an inert record behind on
+ * every relaunch. It is safe to run concurrently with any other attach because it only
+ * removes records that ALREADY resolve to null — the claim is the single source of truth, and
+ * a record the claim does not name is not an attachment whichever way the race went.
+ *
+ * Failures are reported, not swallowed, but are not fatal: the attachment itself is complete
+ * before this runs, and a record left behind costs disk, never a wrong answer.
  */
-async function supersede(keep: string, kildId: string, handle: string): Promise<void> {
+async function sweepSuperseded(): Promise<void> {
   const dir = attachmentsDir();
   let entries: string[];
   try {
     entries = await fs.readdir(dir);
   } catch (err) {
-    console.error(
-      `kild: could not check ${dir} for other sessions holding @${handle}: ${(err as Error).message}`,
-    );
+    console.error(`kild: could not tidy ${dir}: ${(err as Error).message}`);
     return;
   }
   await Promise.all(
@@ -184,16 +191,15 @@ async function supersede(keep: string, kildId: string, handle: string): Promise<
       .filter((entry) => entry.endsWith('.json'))
       .map(async (entry) => {
         const file = path.join(dir, entry);
-        if (file === keep) return;
-        // One unreadable sibling must not fail the attach, but it is exactly the case where a
-        // duplicate claim could survive unseen — so say so instead of skipping in silence.
         try {
           const record = await readRecord(file);
-          if (record?.kildId === kildId && record.handle === handle) {
+          if (!record) return;
+          const owner = await readClaim(record.kildId, record.handle);
+          if (owner !== null && owner !== path.basename(entry, '.json')) {
             await fs.rm(file, { force: true });
           }
         } catch (err) {
-          console.error(`kild: could not supersede ${file}: ${(err as Error).message}`);
+          console.error(`kild: could not tidy ${file}: ${(err as Error).message}`);
         }
       }),
   );
@@ -202,10 +208,18 @@ async function supersede(keep: string, kildId: string, handle: string): Promise<
 /**
  * The session's attachment, or null when it has none.
  *
- * Only *absent* is null. Anything that means "there may be an attachment and I cannot read
- * it" throws, so a caller that must not act on a guess does not get one. The turn-end hook
+ * Null covers two cases that are the same fact from the caller's side: this session never
+ * attached, and this session's claim on the handle has since been taken by another session
+ * (the fork case). It does NOT cover "there may be an attachment and I cannot read it" —
+ * that throws, so a caller which must not act on a guess does not get one. The turn-end hook
  * catches and degrades to silence; `kild send` lets it through and fails.
+ *
+ * Read-only by design: this runs on every turn from a hook, and a read path that mutates
+ * state is a read path that can fail somebody's turn.
  */
 export async function findAttachment(session: string): Promise<Attachment | null> {
-  return readRecord(recordPath(session));
+  const record = await readRecord(recordPath(session));
+  if (!record) return null;
+  const owner = await readClaim(record.kildId, record.handle);
+  return owner === session ? record : null;
 }

--- a/engine/src/kild/attachment.ts
+++ b/engine/src/kild/attachment.ts
@@ -79,8 +79,19 @@ function recordPath(session: string): string {
   return path.join(attachmentsDir(), `${safeSegment('session id', session)}.json`);
 }
 
-/** Kild and handle are separate path segments rather than one joined name: a separator
- *  inside either value could otherwise make two different pairs collide on one filename. */
+/**
+ * Kild and handle are separate path segments rather than one joined name: a separator inside
+ * either value could otherwise make two different pairs collide on one filename.
+ *
+ * KNOWN GAP, deliberately not closed here: on a case-insensitive filesystem (the macOS
+ * default) two handles differing only in case — `Alice` and `alice` — are distinct agents to
+ * the engine's roster but fold to ONE claim file. The second attach overwrites the first, and
+ * the first session then reads as not attached. It fails closed, never to somebody else's
+ * identity, so it cannot mis-attribute; but it does go quiet, which is the failure this file
+ * exists to make impossible. Handles that differ only in case are ambiguous to a reader too,
+ * so the durable fix is for the engine to refuse them on the roster rather than for this file
+ * to encode around them — that is a change to agent admission, not to storage.
+ */
 function claimPath(kildId: string, handle: string): string {
   return path.join(
     attachmentsDir(),

--- a/engine/src/kild/engine-client.ts
+++ b/engine/src/kild/engine-client.ts
@@ -58,16 +58,25 @@ export async function newKild(req: NewKildRequest): Promise<NewKildResponse> {
 const selfAgentId = (): string | undefined => process.env.KILD_AGENT_ID || undefined;
 
 /** `to` names the agents being addressed, exactly as the in-kild `send` tool does, and
- *  like it, it is required — the engine has no default recipient to fall back to. */
+ *  like it, it is required — the engine has no default recipient to fall back to.
+ *
+ *  `token` is the attached-harness credential from `attach`. An agent kild spawned proves
+ *  itself with `agentId`; an attached one has no such process and this is the only way it
+ *  can name itself as the thing it is already addressed as. Presenting neither is correct
+ *  for a human's shell and lands on the log as the unattributed label. */
 export async function sendMessage(
   kildId: string,
   to: string[],
   text: string,
   agentId: string | undefined = selfAgentId(),
+  token?: string,
 ): Promise<KildActionResponse> {
   return engineFetch(`/api/kilds/${encodeURIComponent(kildId)}/messages`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
     body: JSON.stringify({ to, text, ...(agentId ? { agentId } : {}) }),
   });
 }

--- a/hooks/claude-stop
+++ b/hooks/claude-stop
@@ -28,20 +28,35 @@
 # previous generation did.
 set -eu
 
-# Not in a kild → this session is completely unaffected. The common case, and the fastest.
-[ -n "${KILD_KILD_ID:-}" ] || exit 0
 # No kild on PATH (another machine, a stale wiring) → silence, never a hook error.
 command -v kild >/dev/null 2>&1 || exit 0
 
-# Consume the hook payload on stdin so Claude Code never writes into a closed pipe. kild
-# reads nothing from it: the kild and handle come from the environment, and the loop guard
-# is the engine's consecutive-wake cap rather than the payload's `stop_hook_active` — so it
-# lives in one place and no hook can opt out of it.
-cat >/dev/null 2>&1 || true
+# Consume the payload on stdin so Claude Code never writes into a closed pipe. It carries
+# `session_id` — the key `attach` recorded under — which is why this no longer discards it.
+# That id is the ONLY channel that survives a fork: `--resume`/`--fork-session` mints a new
+# session, and a harness settings file can re-inject a stale kild id on every start, so
+# neither the environment nor the launching shell can be trusted to name the right kild.
+#
+# The id and handle are left to `kild inbox` to resolve. It ranks this session's recorded
+# attachment ABOVE $KILD_KILD_ID for that reason: a stale settings-file value cannot win
+# over a real attach. Passing --as only when $KILD_HANDLE is set keeps "pin up front"
+# working without overriding the handle the record already knows.
+PAYLOAD=$(cat 2>/dev/null || true)
+SESSION="${CLAUDE_CODE_SESSION_ID:-}"
+if [ -z "$SESSION" ]; then
+  SESSION=$(printf '%s' "$PAYLOAD" |
+    sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+fi
+
+# Nothing to resolve from → this session is completely unaffected, and fast.
+[ -n "${KILD_KILD_ID:-}" ] || [ -n "$SESSION" ] || exit 0
 
 # stderr is discarded: stray chatter on a hook reads as a failure. Any non-zero exit from
-# the CLI (it should never produce one in this mode) degrades to silence as well.
-kild inbox "$KILD_KILD_ID" \
-  --as "${KILD_HANDLE:-claude}" \
+# the CLI (it should never produce one in this mode) degrades to silence as well. The loop
+# guard is the engine's consecutive-wake cap, not the payload's `stop_hook_active`, so it
+# lives in one place and no hook can opt out of it.
+kild inbox \
+  ${SESSION:+--session "$SESSION"} \
+  ${KILD_HANDLE:+--as "$KILD_HANDLE"} \
   --format claude-stop 2>/dev/null || exit 0
 exit 0

--- a/hooks/claude-stop
+++ b/hooks/claude-stop
@@ -10,13 +10,19 @@
 #        { "hooks": { "Stop": [ { "hooks": [ { "type": "command",
 #            "command": "/abs/path/to/kild/hooks/claude-stop" } ] } ] } }
 #
-#   2. In the environment of the session you want attached (the same names the engine
-#      sets on the agents it spawns, so an attached agent describes itself identically):
-#        export KILD_KILD_ID=<kild id from `kild ls`>
-#        export KILD_HANDLE=claude              # optional, defaults to `claude`
+#   2. Claim a handle, from any session, at any time — this is the whole setup:
+#        kild attach <kild id from `kild ls`> --as claude
 #
-#   3. Claim the handle once the kild exists:
-#        kild attach "$KILD_KILD_ID" --as "$KILD_HANDLE"
+#      `attach` records that against the id of the session that ran it, and the drain below
+#      resolves the same id, so the session that attaches is the session that receives. A
+#      session can therefore attach to a kild opened AFTER it started, which is the normal
+#      case and which no environment variable could ever support.
+#
+#   3. Optional, and no longer the way in: export KILD_KILD_ID / KILD_HANDLE to pin a
+#      session to one kild up front. There is NO default handle — an attach knows which
+#      handle it claimed, so nothing has to guess one. Both variables now LOSE to an actual
+#      attach, because a harness settings file re-injects them on every start including
+#      resumes and a stale one naming an archived kild would drain nothing forever.
 #
 # The contract, in one line: print the drain's JSON, or print nothing, and ALWAYS exit 0.
 # A hook that cannot reach kild must never stop you from finishing a turn.


### PR DESCRIPTION
Two failures with one cause: the CLI knew nothing about the harness session it runs inside.

Both were found by dogfooding — two agents (`@kild` on the engine, `@claude` on the helm rewrite) working the same kild during the helm port. Neither is theoretical.

## Attribution

`attach` mints a bearer token, and the engine writes that handle as `from` when it is presented. The CLI took the token, printed it under `--json`, and **threw it away** — `engineFetch` never set an `Authorization` header. So every send from an attached harness landed as the unattributed label `human`, indistinguishable from the operator typing and from every other attached agent in the kild.

Observed live: two agents' messages and the operator's smoke tests were all `human → [...]` on one log, while the operator was away.

`send` now mints through the idempotent `attach` at call time and presents it. **The token is deliberately not stored** — it lives in engine memory (`AttachTokens`) and dies with the engine, so a copy on disk would outlive the thing it names and be rejected as `unknown attach token` on the next send.

## Discovery

An attached agent was reachable only if `KILD_KILD_ID` was in the environment, and a process's environment is fixed at exec time — so a session could not attach to a kild opened *after* it started, which is the normal case, since you decide to delegate mid-session. `export` in a tool call changes a child shell, never the harness.

A resumed or forked session is worse: its environment is rebuilt from a harness settings file no shell owns. The operator relaunched a session three times in one day trying to fix this from the shell, and could not.

`attach` now records `{kild, handle}` against the harness session id — an opaque string kild stores and hands back. `inbox` and `send` resolve it. `kild attach <id> --as <handle>` is now the entire setup.

### The record outranks the environment

This is the opposite of the obvious ordering, and it is the interesting part of the change.

A harness settings file (`.claude/settings.local.json`) is re-read on **every** session start including resumes, outranks anything a shell exports, and cannot be cleared from the shell. A stale entry naming an **archived** kild is therefore invisible and unkillable — it would drain nothing forever while reporting success, which is precisely the failure `hooks/claude-stop`'s own header warns about.

An `attach` is a deliberate act naming a kild that existed at the time; ambient config nobody re-reads loses to it. `KILD_KILD_ID` still works, as the fallback.

Resolution: **explicit argument > this session's recorded attach > environment.**

### Supersession

Attaching supersedes any other session holding the same `(kild, handle)`. A session id is not stable — `--fork-session` mints a new one for what the operator experiences as the same session — so without this, records accumulate one per relaunch. And a handle is one identity: two live sessions sharing it would race on one destructive inbox, each eating mail meant for the other.

### Spawned agents are guarded out

The engine sets `KILD_KILD_ID` and `KILD_HANDLE` on the agents it spawns too. Without the `KILD_AGENT_ID` guard, `kild send` from an owned agent would have attached a second, shadow handle over the agent's own and spoken through it. Covered by a test.

## Two things found by running it, not by testing it

- **`harnessSession` was a `const` arrow reached by `dispatch()` before initialisation**, which broke `kild attach` outright with `Cannot access 'harnessSession' before initialization`. `dispatch()` runs at the top of the module, so anything it reaches must be hoisted. It is a function declaration now. No unit test would have caught this; running the binary did, immediately.
- **`cli.attached.test.ts` inherited the ambient environment** (`env: { ...process.env }`). Harmless before — `cli.ts` read none of those vars. Now the suite resolved *the operator's own attachment* and passed or failed depending on whose machine it ran on. The harness scrubs the identity vars and redirects `KILD_HOME` to a temp dir; tests opt into an identity by name.

## Gates

| Gate | Result |
|---|---|
| `bun test` | **400 pass, 0 fail** |
| `bun run typecheck` | pass |
| `bun run lint` | pass |
| `./scripts/e2e.sh` | **70 checks, 0 fail** |

Verified live against the running engine on 4517: attach → record on disk → an attributed send landing as `kild → [claude]` instead of `human` → a drain resolved with `KILD_KILD_ID` and `KILD_HANDLE` explicitly unset.

## Boundary

The engine learns nothing about any harness. It stores no session id and gains no new field; the record is written by the CLI, and only `hooks/claude-stop` knows where the id comes from. Vendor knowledge stays in the vendor file.

## For an existing setup

`docs/upgrading.md` has the full list. In short: re-copy `hooks/claude-stop`, and **check your harness settings file for a leftover `KILD_ROOM`/`KILD_PARTICIPANT`** — renaming the variables did not remove the stale entry, and it is exactly the invisible trap described above.
