### PR TITLE
docs: the failure shapes a client cannot learn from the routes

### DIFF
--- a/docs/api-surface.md
+++ b/docs/api-surface.md
@@ -222,3 +222,53 @@ The registry itself is load-bearing and stays — it scopes the unscoped `GET /a
 resolves `--project` / `project=` — but a loopback write route for a local file the operator
 owns was a second way to do what `kild project add` already does. Cheap to reinstate if a UI
 ever wants a project picker; there is no reason to carry it until one does.
+
+## 10. Failure shapes a client cannot learn from the routes
+
+Two responses on this surface are not what their status code suggests. Both were found by a
+client porting against it, in both cases after the wrong guess had already shipped — so they
+are written down rather than changed. Neither is a defect; each is a real distinction the wire
+makes and the docs did not.
+
+### `POST /api/kilds/:id/land` returns 409 from two places, with different bodies
+
+```
+refused merge        409  { ...full land report, dryRun: false }   // landMerge said !merged
+unresolvable target  409  { error, code }                          // resolveKild refused first
+```
+
+`kildResultStatus` maps every non-`not_found` failure to 409, so a kild that is archived,
+orphaned or otherwise unaddressable answers with a bare `{error, code}` — while a merge that
+genuinely would not apply answers with the **entire** report, which also contains an `error`.
+A real example of the bare form:
+
+```json
+{ "error": "kild c8971dd5 is archived (its agents are gone) — address its tree as 'sidebar-observe'",
+  "code": "invalid_state" }
+```
+
+**Discriminate on a field only the report carries — `wouldMerge` — never on the presence of
+`error`.** A client that decodes every 409 as a report throws on the bare one and replaces that
+message with a decode failure. That is worse than the original error: the message names the fix
+(address the tree by name), and losing it makes a correctly-behaving engine look broken.
+
+The two really are different kinds of failure — one is "this merge will not apply", the other
+is "there is nothing here to merge" — which is why the shapes differ and why this is a
+documentation fix rather than an API change.
+
+### `GET /api/kilds/:id/agents/:handle/transcript` refuses for an attached agent
+
+```
+owned     200  { entries: [{ role, text, toolCalls? }], total }
+attached  404  { error: "agent @claude has no pi session file (yet)" }
+```
+
+`ownership` decides the **source**, not the fidelity. An attached agent is a harness kild does
+not own, so there is no pi session to read and the route refuses rather than returning an empty
+transcript — empty would assert that the agent has done nothing, when the truth is that the
+question has no answer here. A client should read the kild's message log for those agents
+instead; it is a different source, not a thinner view of the same one.
+
+One detail of the `owned` shape that quietly breaks a careless renderer: an assistant turn that
+**only** calls tools has `text: ""` with the calls in `toolCalls`. Rendering `text` alone drops
+precisely the turns that did something.

--- a/docs/helm-migration.md
+++ b/docs/helm-migration.md
@@ -192,6 +192,33 @@ view. `GET /api/kilds` does not carry the field. What it *does* carry is `git.ch
 full per-kild changed-file list, which is everything needed to derive collisions client-side.
 Deriving them in helm from `git.changedFiles` is the correct approach, not a workaround.
 
+#### Three states, not two — an empty `changedFiles` is not always "clean"
+
+`changedFiles` is **not optional**: `KildGitStatus.changedFiles` is `string[]` and is always
+present. What *is* optional is the whole `git` block, so "not measured" is encoded by `git`
+being absent, never by the list being absent.
+
+The state that catches people is the third one. `worktree-status.ts` captures git failures as
+**data** — `error?: string`, documented there as "any git failure captured here, NEVER thrown"
+— and leaves `ahead`/`behind` at 0 and `changedFiles` empty when it fires:
+
+| Shape | Means |
+|---|---|
+| `git` absent | not measured |
+| `git` present, `changedFiles: []`, no `error` | measured, genuinely clean |
+| `git` present, `changedFiles: []`, `error` set | **measurement failed — nothing is known** |
+
+So an empty list with `error` set is *not* "this kild collides with nothing", it is "we cannot
+tell what this kild touches". Rendering the two the same makes a client state confidently that
+there are no collisions at exactly the moment it cannot know — and a land gate is the last
+place that answer should be guessed. Treat `error` as undetermined and render it as such;
+`conflictsWithBase` is already `boolean | null` with `null` meaning explicitly undetermined, so
+undetermined is a state this wire expects you to have a rendering for.
+
+Note also that only the **full** `/status` shape carries the list. `GET /api/kilds` has no
+`git` at all, and the compact form reduces it to `changedFileCount`. Derivation only works
+where the list actually is.
+
 ### Request body changes
 
 - `POST /api/kilds` — `participants: [{name, persona, model}]` → `agents: [{handle, persona, model}]`


### PR DESCRIPTION
Documentation only — no behaviour changes. Three distinctions the wire makes that the docs did not, all found by helm porting against the merged surface, and in two cases only after the wrong guess had shipped.

## An empty `changedFiles` is not always "clean"

`helm-migration.md` tells clients to derive `collidesWith` from `git.changedFiles` and never mentioned `git.error`. There are **three** states, not two:

| Shape | Means |
|---|---|
| `git` absent | not measured |
| `git` present, `changedFiles: []`, no `error` | measured, genuinely clean |
| `git` present, `changedFiles: []`, `error` set | **measurement failed** |

`worktree-status.ts` captures git failures as data (`error?: string`, documented there as *"any git failure captured here, NEVER thrown"*) and leaves the list empty when that fires. A client following the doc as written would report "collides with nothing" at exactly the moment it cannot tell — and that answer feeds a land gate.

The list itself is **not** optional; `git` is. A client guarding an optional `changedFiles` is guarding a state that never occurs while leaving the real one unguarded.

## `POST /land` returns 409 from two places, with different bodies

```
refused merge        409  { ...full land report, dryRun: false }
unresolvable target  409  { error, code }
```

`kildResultStatus` maps every non-`not_found` failure to 409, so an archived or orphaned target answers with a bare `{error, code}` while a merge that would not apply answers with the entire report — which also contains an `error`. That field therefore cannot discriminate them; `wouldMerge` can.

A client decoding every 409 as a report throws on the bare one and replaces a message that names the fix with an opaque decode error:

```json
{ "error": "kild c8971dd5 is archived (its agents are gone) — address its tree as 'sidebar-observe'",
  "code": "invalid_state" }
```

Losing that makes a correctly-behaving engine look broken. Documented rather than changed: the two really are different kinds of failure, and helm is mid-port against this surface.

## The transcript route refuses for an attached agent

```
owned     200  { entries: [{ role, text, toolCalls? }], total }
attached  404  { error: "agent @claude has no pi session file (yet)" }
```

`ownership` decides the **source**, not the fidelity. Refusing is correct — an empty transcript would assert the agent had done nothing, when the truth is the question has no answer for a harness kild does not own. Those agents' history is the kild message log, a different source rather than a thinner view.

Also noted: an assistant turn that **only** calls tools has `text: ""` with the calls in `toolCalls`, so a renderer reading `text` alone silently drops precisely the turns that acted.

## Verification

Every claim was checked against the source rather than transcribed from the report that raised it — `server.ts:907-923` and `kildResultStatus` for the dual 409, `server.ts:257-271` for the transcript refusal, `worktree-status.ts` for the `error` semantics.