### PR TITLE
build(engine): catch switch fallthrough

### DIFF
--- a/engine/tsconfig.json
+++ b/engine/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
**Zero errors on the existing tree.** Costs nothing to adopt, blocks no idiom, and catches a real class for an engine with this many switch-on-code paths — where a missing `return` silently runs the next case's body.

Verified rather than assumed: a deliberate fallthrough fails typecheck, and removing it passes.

## What this replaced

A four-flag suggestion, measured one at a time rather than adopted as a set:

| flag | verdict | why |
|---|---|---|
| `noFallthroughCasesInSwitch` | **adopt** | 0 errors, no idiom blocked |
| `exactOptionalPropertyTypes` | skip | 45 errors; fixes make code worse to read |
| `noUnusedLocals` | skip | biome already does it, better |
| `noUnusedParameters` | skip | same |

### On `exactOptionalPropertyTypes`

The argument for it was that today produced three bugs about present-but-meaningless being indistinguishable from absent. True — but the flag only catches the **mechanical** half. The ones that actually cost time were semantic: `changedFiles: []` beside an `error`, `discarded: []` beside `discardedError`, `conflictsWithBase: null` meaning *undetermined*. No compiler flag catches those.

What does catch them is a comment on the field stating which absence means what, which is already the practice in this codebase. Meanwhile the flag's cost is certain: 45 errors whose fixes are conditional spreads and piecemeal object construction.

### On the unused-code flags

Confirmed by probe rather than by reading config — biome reports both today:

```
lint/correctness/noUnusedFunctionParameters  FIXABLE
lint/correctness/noUnusedVariables           FIXABLE
```

That's the right layer: fixable, and suppressible per-line with a reason. A compiler flag turns an unused callback parameter into a build failure whose only workaround is renaming to `_`.

## Gates

457 tests, typecheck, lint, e2e 70/70.