### PR TITLE
docs: the drain is a POST, and the model doc said GET

### DIFF
--- a/docs/model.html
+++ b/docs/model.html
@@ -609,7 +609,7 @@
           <tr><td class="mono">POST /api/kilds/:id/agents</td><td>Spawn an <code>owned</code> agent into the kild (handle, persona, model).</td><td class="mono"><span class="was">invite_agent / room_add</span></td></tr>
           <tr><td class="mono seal-t">POST /api/kilds/:id/agents/attach</td><td>Register an <code>attached</code> agent — the honryo. Idempotent; addressable at once.</td><td class="mono"><span class="was">joinRoom (room join)</span></td></tr>
           <tr><td class="mono">POST /api/kilds/:id/messages</td><td>Send — <code>{ from, to[], text }</code> into recipients' inboxes.</td><td class="mono"><span class="was">postRoom / room_post</span></td></tr>
-          <tr><td class="mono">GET /api/kilds/:id/inbox?as=</td><td>Drain an attached agent's inbox (the pull side).</td><td class="mono"><span class="was">drainRoom (room drain)</span></td></tr>
+          <tr><td class="mono">POST /api/kilds/:id/inbox/drain</td><td>Drain an attached agent's inbox (the pull side). POST, never GET — it MUTATES, so a cache or a retry on a GET would silently eat somebody's mail.</td><td class="mono"><span class="was">drainRoom (room drain)</span></td></tr>
           <tr><td class="mono">GET /api/kilds</td><td>List + observe: participants, git status, cost rollup, collisions.</td><td class="mono"><span class="was">getLiveRooms / rooms_status</span></td></tr>
           <tr><td class="mono">GET /api/kilds/:id</td><td>One kild — detail + full message log.</td><td class="mono"><span class="was">room show / room log</span></td></tr>
           <tr><td class="mono d-new">POST /api/kilds/:id/land</td><td>Merge toward base; return the collision/merge report.</td><td class="mono">new — was implicit prune</td></tr>


### PR DESCRIPTION
`docs/model.html` — the **current**-model document, not a historical one — listed the inbox drain as:

```
GET /api/kilds/:id/inbox?as=
```

The engine serves `POST /api/kilds/:id/inbox/drain`. Wrong method **and** wrong path.

The method is wrong in precisely the way the route deliberately guards against. From `server.ts`, three lines above the handler:

> POST, never GET: this MUTATES, so a caching proxy or a retry on a GET would silently eat somebody's messages.

So the doc pointed a client at the thing the engine refuses to offer, for a reason the engine had already written down.

## Verified rather than spot-checked

Diffed every route the doc names against every route the server registers. **That was the only mismatch** — all others are accurate.

The dead verbs elsewhere in the file (`kild room open`, `room join`, `room drain`) are all in a **"Was"** column of a before/after table, which is what that column is for. Not a defect.

## Why I looked

helm's agent hit the same thing an hour ago — their `AGENTS.md` still told the next agent to use a `--room` flag that no longer exists — and named the pattern we'd both hit five times by then:

> **The thing that verifies is the thing nobody verifies.**

Instructions are verification too. They tell the next reader what to check against, and nothing checks them.